### PR TITLE
feat(scope): modo profile operante — selects, Provenance e Collection Target (#9)

### DIFF
--- a/src/background/controller.ts
+++ b/src/background/controller.ts
@@ -762,5 +762,13 @@ export function handleRuntimeMessage(
     };
   }
 
+  if (request.action === "DETECT_TARGET") {
+    const profile = BACKGROUND_PROVIDERS[request.provider]?.scopeModes.find(
+      (mode) => mode.id === "profile",
+    );
+    const target = profile?.detectFromPage?.(request.pageUrl) ?? null;
+    return { mode: "profile", target };
+  }
+
   return undefined;
 }

--- a/src/background/controller.ts
+++ b/src/background/controller.ts
@@ -98,6 +98,7 @@ export function createStore(trackedHandle = ""): BackgroundStore {
     providerPageUrls: {},
     trackedHandles: {},
     trackedProfiles: {},
+    provenance: {},
   };
 }
 
@@ -190,6 +191,7 @@ function clearNormalizedData(store: BackgroundStore) {
   store.platforms.linkedin.extra.accountInfo = linkedinAccountInfo;
 
   store.trackedProfiles = {};
+  store.provenance = {};
   store.nextCaptureOrder = 1;
 }
 

--- a/src/background/store.ts
+++ b/src/background/store.ts
@@ -57,6 +57,19 @@ export function trackedHandleForProvider(store: BackgroundStore, provider: Socia
   return (store.trackedHandles[provider] ?? store.trackedHandle).trim();
 }
 
+// Grava a Provenance do Scope (#9) de uma publicação: qual modo/valor de coleta a trouxe.
+// Mapa interno (store.provenance), nunca exportado no v3 — ver ScopeProvenance em domain.ts.
+export function recordProvenance(
+  store: BackgroundStore,
+  provider: SocialProvider,
+  publicationId: string,
+  mode: string,
+  value: string,
+) {
+  const map = (store.provenance[provider] ??= {});
+  map[publicationKey(provider, publicationId)] = { mode, value };
+}
+
 export function storePublication(store: BackgroundStore, publication: SocialPublication) {
   const provider = publication.provider;
   const key = publicationKey(provider, publication.publication_id);

--- a/src/background/store.ts
+++ b/src/background/store.ts
@@ -66,8 +66,9 @@ export function recordProvenance(
   mode: string,
   value: string,
 ) {
-  const map = (store.provenance[provider] ??= {});
+  const map = store.provenance[provider] ?? {};
   map[publicationKey(provider, publicationId)] = { mode, value };
+  store.provenance[provider] = map;
 }
 
 export function storePublication(store: BackgroundStore, publication: SocialPublication) {

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -12,6 +12,8 @@
       <h1>He4rt Analytics</h1>
     </div>
 
+    <div id="collectionTarget" class="collection-target hidden"></div>
+
     <div class="tabs">
       <button class="tab active" data-tab="x" type="button">X</button>
       <button class="tab" data-tab="instagram" type="button">Instagram</button>

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -77,6 +77,8 @@ function switchTab(tabId: string) {
   if (tabId === "all") loadAllSummary();
   else if (tabId === "config") loadHandles();
   else loadPlatformData(tabId as SocialProvider);
+
+  renderCollectionTarget();
 }
 
 function autoSelectTab() {
@@ -114,14 +116,22 @@ function providerFromUrl(url: string): null | SocialProvider {
   return null;
 }
 
+// Estado da última detecção (da aba do BROWSER ativa). O banner é global no popup, então
+// só o exibimos quando a aba do POPUP ativa é a do provider detectado — senão o "Perfil
+// detectado no X" apareceria também nas abas Instagram/LinkedIn/Resumo/Config.
+let detectedTarget: { handles: HandlesMap; provider: SocialProvider; target: string } | null = null;
+
+function activePopupTab(): null | string {
+  return (document.querySelector(".tab.active") as HTMLElement | null)?.dataset.tab ?? null;
+}
+
 function suggestCollectionTarget() {
-  const banner = document.getElementById("collectionTarget");
-  if (!banner) return;
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     const url = tabs[0]?.url;
     const provider = url ? providerFromUrl(url) : null;
     if (!url || !provider) {
-      banner.classList.add("hidden");
+      detectedTarget = null;
+      renderCollectionTarget();
       return;
     }
     chrome.runtime.sendMessage(
@@ -129,13 +139,15 @@ function suggestCollectionTarget() {
       (res: { mode: string; target: null | string } | undefined) => {
         const target = res?.target ?? null;
         if (!target) {
-          banner.classList.add("hidden");
+          detectedTarget = null;
+          renderCollectionTarget();
           return;
         }
         chrome.runtime.sendMessage(
           { action: "GET_HANDLES" },
           (handlesRes: { handles: HandlesMap } | undefined) => {
-            renderCollectionTarget(banner, provider, target, handlesRes?.handles || {});
+            detectedTarget = { provider, target, handles: handlesRes?.handles || {} };
+            renderCollectionTarget();
           },
         );
       },
@@ -143,12 +155,15 @@ function suggestCollectionTarget() {
   });
 }
 
-function renderCollectionTarget(
-  banner: HTMLElement,
-  provider: SocialProvider,
-  target: string,
-  handles: HandlesMap,
-) {
+function renderCollectionTarget() {
+  const banner = document.getElementById("collectionTarget");
+  if (!banner) return;
+  // Só exibe na aba do popup correspondente ao provider detectado.
+  if (!detectedTarget || activePopupTab() !== detectedTarget.provider) {
+    banner.classList.add("hidden");
+    return;
+  }
+  const { provider, target, handles } = detectedTarget;
   const meta = TABS.find((t) => t.provider === provider);
   const label = meta?.name ?? provider;
   const color = meta?.color ?? "#888";

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -57,6 +57,7 @@ document.addEventListener("DOMContentLoaded", () => {
   setupButtons();
   setupListeners();
   autoSelectTab();
+  suggestCollectionTarget();
 });
 
 const HOST_TAB_MAP: Array<{ host: string; tab: string }> = PROVIDER_METAS.flatMap((meta) =>
@@ -92,6 +93,85 @@ function autoSelectTab() {
       }
     }
     switchTab("all");
+  });
+}
+
+// === Collection Target (#9) ===
+// Sugere o alvo de coleta a partir da URL da aba ativa: pergunta ao background
+// (DETECT_TARGET → detectFromPage do scopeModes.profile) e mostra um banner com o perfil
+// detectado + botão para rastrear. Profile-only por enquanto (único modo).
+
+const HANDLE_INPUT_IDS: Record<string, string> = {
+  x: "handleX",
+  instagram: "handleIg",
+  linkedin: "handleLi",
+};
+
+function providerFromUrl(url: string): null | SocialProvider {
+  for (const { host, tab } of HOST_TAB_MAP) {
+    if (url.includes(host)) return tab as SocialProvider;
+  }
+  return null;
+}
+
+function suggestCollectionTarget() {
+  const banner = document.getElementById("collectionTarget");
+  if (!banner) return;
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    const url = tabs[0]?.url;
+    const provider = url ? providerFromUrl(url) : null;
+    if (!url || !provider) {
+      banner.classList.add("hidden");
+      return;
+    }
+    chrome.runtime.sendMessage(
+      { action: "DETECT_TARGET", provider, pageUrl: url },
+      (res: { mode: string; target: null | string } | undefined) => {
+        const target = res?.target ?? null;
+        if (!target) {
+          banner.classList.add("hidden");
+          return;
+        }
+        chrome.runtime.sendMessage(
+          { action: "GET_HANDLES" },
+          (handlesRes: { handles: HandlesMap } | undefined) => {
+            renderCollectionTarget(banner, provider, target, handlesRes?.handles || {});
+          },
+        );
+      },
+    );
+  });
+}
+
+function renderCollectionTarget(
+  banner: HTMLElement,
+  provider: SocialProvider,
+  target: string,
+  handles: HandlesMap,
+) {
+  const meta = TABS.find((t) => t.provider === provider);
+  const label = meta?.name ?? provider;
+  const color = meta?.color ?? "#888";
+  const tracked = (handles[provider] || "").toLowerCase() === target.toLowerCase();
+  const safeTarget = escapeHtml(target);
+  banner.classList.remove("hidden");
+
+  if (tracked) {
+    banner.innerHTML = `<span class="ct-dot" style="background:${color}"></span><span class="ct-text">Coletando <strong>${safeTarget}</strong> no ${label} · modo Profile</span>`;
+    return;
+  }
+
+  banner.innerHTML = `<span class="ct-dot" style="background:${color}"></span><span class="ct-text">Perfil detectado: <strong>${safeTarget}</strong></span><button id="ctTrackBtn" class="btn btn-xs" type="button">Rastrear</button>`;
+  document.getElementById("ctTrackBtn")?.addEventListener("click", () => {
+    const merged: HandlesMap = { ...handles, [provider]: target };
+    chrome.runtime.sendMessage({ action: "SET_HANDLES", handles: merged }, () => {
+      const input = document.getElementById(
+        HANDLE_INPUT_IDS[provider] || "",
+      ) as HTMLInputElement | null;
+      if (input) input.value = target;
+      suggestCollectionTarget();
+      loadPlatformData(provider);
+    });
   });
 }
 
@@ -139,9 +219,15 @@ function setupListeners() {
     }
   });
 
-  chrome.tabs.onActivated?.addListener(() => autoSelectTab());
+  chrome.tabs.onActivated?.addListener(() => {
+    autoSelectTab();
+    suggestCollectionTarget();
+  });
   chrome.tabs.onUpdated?.addListener((_tabId, changeInfo) => {
-    if (changeInfo.status === "complete" || changeInfo.url) autoSelectTab();
+    if (changeInfo.status === "complete" || changeInfo.url) {
+      autoSelectTab();
+      suggestCollectionTarget();
+    }
   });
 }
 

--- a/src/popup/styles.css
+++ b/src/popup/styles.css
@@ -423,3 +423,36 @@ body {
   overflow-y: auto;
   max-height: 430px;
 }
+
+/* Collection Target (#9) — banner do alvo de coleta detectado da aba ativa */
+.collection-target {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 12px 8px;
+  padding: 8px 12px;
+  background: rgba(231, 233, 234, 0.04);
+  border: 1px solid rgba(231, 233, 234, 0.08);
+  border-radius: 12px;
+  font-size: 12px;
+}
+.collection-target.hidden {
+  display: none;
+}
+.ct-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+.ct-text {
+  flex: 1;
+  color: #c9d1d9;
+}
+.ct-text strong {
+  color: #fff;
+}
+.btn-xs {
+  padding: 4px 12px;
+  font-size: 11px;
+}

--- a/src/providers/contract.ts
+++ b/src/providers/contract.ts
@@ -10,6 +10,9 @@ export type CaptureProcessor = (store: BackgroundStore, capture: CapturedPayload
 export type BackgroundProviderFacet = {
   id: SocialProvider;
   processCapture: CaptureProcessor;
+  // Modos de Scope (#9) declarados pelo provider — usados pela detecção de Collection
+  // Target (DETECT_TARGET/detectFromPage) e pelo filtro por modo. Ver ScopeMode abaixo.
+  scopeModes: ScopeMode[];
 };
 
 // Seam de Scope (#9): torna o modo de coleta DECLARÁVEL por provider sem mover ainda

--- a/src/providers/instagram/index.ts
+++ b/src/providers/instagram/index.ts
@@ -1,5 +1,6 @@
 import {
   emptyMetrics,
+  recordProvenance,
   recordRawPayload,
   storeComment,
   storeEngagement,
@@ -160,9 +161,16 @@ function migratePublicationRelations(
   migrateEngagements(istore.engagementsByPublication, istore.engagementsByPublication);
 }
 
+// Predicate do modo "profile" do Instagram: a publicação é do perfil rastreado quando o
+// username do autor casa com o valor de coleta. Fonte ÚNICA — reusada pelo scopeModes
+// .selects() (#9) e pelo filtro de conteúdo de processInstagramCapture.
+const isIgProfilePublication = (pub: SocialPublication, value: string) =>
+  pub.author.username?.toLowerCase() === value.toLowerCase();
+
 export function processInstagramCapture(store: BackgroundStore, request: CapturedPayloadMessage) {
   const istore = store.platforms.instagram;
-  const handle = trackedHandleForProvider(store, "instagram").toLowerCase();
+  const trackedHandle = trackedHandleForProvider(store, "instagram");
+  const handle = trackedHandle.toLowerCase();
   const publications = extractInstagramPublications(request.payload);
   const pageShortcode = instagramShortcodeFromUrl(request.pageUrl);
 
@@ -170,10 +178,13 @@ export function processInstagramCapture(store: BackgroundStore, request: Capture
     if (publication.shortcode && publication.shortcode === pageShortcode) {
       publication.capture_priority = 0;
     }
-    if (!handle || publication.author.username.toLowerCase() === handle) {
+    if (!handle || isIgProfilePublication(publication, handle)) {
       const prevMapping = publication.shortcode
         ? istore.publicationIdsByShortcode[publication.shortcode]
         : undefined;
+      if (handle) {
+        recordProvenance(store, "instagram", publication.publication_id, "profile", trackedHandle);
+      }
       storePublication(store, publication);
       if (publication.shortcode) {
         const prevId = prevMapping;
@@ -183,7 +194,7 @@ export function processInstagramCapture(store: BackgroundStore, request: Capture
         }
         istore.publicationIdsByShortcode[publication.shortcode] = newId;
       }
-      if (publication.author.username.toLowerCase() === handle) {
+      if (isIgProfilePublication(publication, handle)) {
         store.trackedProfiles.instagram = profileFromPublication(publication);
       }
     }
@@ -390,15 +401,15 @@ export function computeSummaryInstagram(store: BackgroundStore): ExportSummaryIn
   };
 }
 
-// Modos de Scope declaráveis (#9). O filtro real continua dentro de
-// processInstagramCapture / instagramPublicationAllowedForComments (compara
-// author.username com o handle); aqui só tornamos o modo "profile" declarável —
-// selects() casa pelo username do autor.
+// Modos de Scope (#9). O modo "profile" usa a MESMA predicate (isIgProfilePublication) que o
+// filtro de conteúdo de processInstagramCapture — fonte única. (O filtro de comentários,
+// instagramPublicationAllowedForComments, é engajamento e segue à parte.) selects() casa
+// pelo username do autor.
 export const scopeModes: ScopeMode[] = [
   {
     id: "profile",
     label: "Profile",
-    selects: (pub, value) => pub.author.username?.toLowerCase() === value.toLowerCase(),
+    selects: isIgProfilePublication,
   },
 ];
 

--- a/src/providers/instagram/index.ts
+++ b/src/providers/instagram/index.ts
@@ -434,4 +434,5 @@ export const scopeModes: ScopeMode[] = [
 export const instagramProvider: BackgroundProviderFacet = {
   id: "instagram",
   processCapture: processInstagramCapture,
+  scopeModes,
 };

--- a/src/providers/instagram/index.ts
+++ b/src/providers/instagram/index.ts
@@ -21,7 +21,7 @@ import type {
 } from "../../shared/domain";
 import type { CapturedPayloadMessage, VisibleCommentsMessage } from "../../shared/messages";
 import type { BackgroundProviderFacet, ScopeMode } from "../contract";
-import { publicationKey } from "../shared/utils";
+import { pathSegments, publicationKey } from "../shared/utils";
 import {
   extractInstagramComments,
   extractInstagramLikers,
@@ -410,6 +410,24 @@ export const scopeModes: ScopeMode[] = [
     id: "profile",
     label: "Profile",
     selects: isIgProfilePublication,
+    // Extrai o username da URL de um perfil do Instagram: instagram.com/<username> (1
+    // segmento, fora dos reservados). Posts/reels/explore/stories → null.
+    detectFromPage: (pageUrl) => {
+      const seg = pathSegments(pageUrl);
+      const candidate = seg.length === 1 ? seg[0] : undefined;
+      if (!candidate) return null;
+      const reserved = new Set([
+        "p",
+        "reel",
+        "reels",
+        "explore",
+        "stories",
+        "direct",
+        "accounts",
+        "about",
+      ]);
+      return reserved.has(candidate.toLowerCase()) ? null : candidate;
+    },
   },
 ];
 

--- a/src/providers/linkedin/index.ts
+++ b/src/providers/linkedin/index.ts
@@ -1,4 +1,5 @@
 import {
+  recordProvenance,
   storeComment,
   storeEngagement,
   storePublication,
@@ -38,6 +39,9 @@ export function processLinkedInCapture(store: BackgroundStore, request: Captured
   if (request.endpoint === "feedDashOrganizationalPageUpdates") {
     const publications = linkedinFeedToPublications(request.payload, handle);
     for (const pub of publications) {
+      // O filtro real (name OU headerText) vive no parser; aqui só gravamos a Provenance
+      // das publicações que já passaram por ele. Ver decisão 3 do plano #9.
+      if (handle) recordProvenance(store, "linkedin", pub.publication_id, "profile", handle);
       storePublication(store, pub);
     }
 

--- a/src/providers/linkedin/index.ts
+++ b/src/providers/linkedin/index.ts
@@ -408,4 +408,5 @@ export const scopeModes: ScopeMode[] = [
 export const linkedinProvider: BackgroundProviderFacet = {
   id: "linkedin",
   processCapture: processLinkedInCapture,
+  scopeModes,
 };

--- a/src/providers/shared/utils.ts
+++ b/src/providers/shared/utils.ts
@@ -32,6 +32,16 @@ export function publicationKey(provider: SocialProvider, publicationId: string) 
   return `${provider}:${publicationId}`;
 }
 
+// Segmentos do path de uma URL (sem vazios). Usado pelo detectFromPage dos scopeModes (#9)
+// para extrair o alvo de coleta a partir da URL da página. Retorna [] se a URL for inválida.
+export function pathSegments(pageUrl: string): string[] {
+  try {
+    return new URL(pageUrl).pathname.split("/").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 export function compactText(value: unknown) {
   return typeof value === "string" ? value : "";
 }

--- a/src/providers/x/index.ts
+++ b/src/providers/x/index.ts
@@ -12,7 +12,7 @@ import type {
 } from "../../shared/domain";
 import type { CapturedPayloadMessage } from "../../shared/messages";
 import type { BackgroundProviderFacet, ScopeMode } from "../contract";
-import { publicationKey } from "../shared/utils";
+import { pathSegments, publicationKey } from "../shared/utils";
 import {
   accountInfoFromUser,
   accountInfoToTrackedProfile,
@@ -133,6 +133,25 @@ export const scopeModes: ScopeMode[] = [
     id: "profile",
     label: "Profile",
     selects: isXProfilePublication,
+    // Extrai o handle da URL de um perfil do X: x.com/<handle> (1 segmento, fora dos
+    // caminhos reservados). URLs que não são perfil (status, search, home…) → null.
+    detectFromPage: (pageUrl) => {
+      const seg = pathSegments(pageUrl);
+      const candidate = seg.length === 1 ? seg[0] : undefined;
+      if (!candidate) return null;
+      const reserved = new Set([
+        "home",
+        "explore",
+        "search",
+        "notifications",
+        "messages",
+        "settings",
+        "i",
+        "compose",
+        "hashtag",
+      ]);
+      return reserved.has(candidate.toLowerCase()) ? null : candidate;
+    },
   },
 ];
 

--- a/src/providers/x/index.ts
+++ b/src/providers/x/index.ts
@@ -158,4 +158,5 @@ export const scopeModes: ScopeMode[] = [
 export const xProvider: BackgroundProviderFacet = {
   id: "x",
   processCapture: processXCapture,
+  scopeModes,
 };

--- a/src/providers/x/index.ts
+++ b/src/providers/x/index.ts
@@ -1,9 +1,15 @@
 import {
+  recordProvenance,
   storeEngagement,
   storePublication,
   trackedHandleForProvider,
 } from "../../background/store";
-import type { BackgroundStore, ExportSummaryX, ExportV3PlatformX } from "../../shared/domain";
+import type {
+  BackgroundStore,
+  ExportSummaryX,
+  ExportV3PlatformX,
+  SocialPublication,
+} from "../../shared/domain";
 import type { CapturedPayloadMessage } from "../../shared/messages";
 import type { BackgroundProviderFacet, ScopeMode } from "../contract";
 import { publicationKey } from "../shared/utils";
@@ -17,6 +23,12 @@ import {
 
 type AnyRecord = Record<string, any>;
 
+// Predicate do modo "profile" do X: a publicação é do perfil rastreado quando o autor
+// (username = screen_name) casa com o valor de coleta. Fonte ÚNICA — reusada tanto pelo
+// scopeModes.selects() (#9) quanto pelo filtro de processXCapture.
+const isXProfilePublication = (pub: SocialPublication, value: string) =>
+  pub.author.username?.toLowerCase() === value.toLowerCase();
+
 export function processXCapture(store: BackgroundStore, request: CapturedPayloadMessage) {
   const trackedHandle = trackedHandleForProvider(store, "x");
   const handle = trackedHandle.toLowerCase();
@@ -26,7 +38,7 @@ export function processXCapture(store: BackgroundStore, request: CapturedPayload
     processUserTweetsPayload(request.payload, trackedHandle, (tweet, publication, rawResult) => {
       const authorHandle = tweet.author.screen_name.toLowerCase();
 
-      if (authorHandle === handle) {
+      if (isXProfilePublication(publication, trackedHandle)) {
         if (!xstore.accountInfo && tweet.author.rest_id) {
           const authorResult = rawResult.core?.user_results?.result;
           const info = accountInfoFromUser(authorResult || {}, tweet);
@@ -34,6 +46,7 @@ export function processXCapture(store: BackgroundStore, request: CapturedPayload
           store.trackedProfiles.x = accountInfoToTrackedProfile(info);
         }
         xstore.tweets[tweet.tweet_id] = tweet;
+        recordProvenance(store, "x", publication.publication_id, "profile", trackedHandle);
         storePublication(store, publication);
       }
 
@@ -112,14 +125,14 @@ export function computeSummaryX(store: BackgroundStore): ExportSummaryX {
   };
 }
 
-// Modos de Scope declaráveis (#9). O filtro real continua dentro de processXCapture
-// (compara author.screen_name com o handle rastreado); aqui só tornamos o modo
-// "profile" declarável — selects() casa pelo username do autor (= screen_name no X).
+// Modos de Scope (#9). O modo "profile" usa a MESMA predicate (isXProfilePublication) que o
+// filtro de processXCapture — fonte única, sem divergência. selects() casa pelo username do
+// autor (= screen_name no X).
 export const scopeModes: ScopeMode[] = [
   {
     id: "profile",
     label: "Profile",
-    selects: (pub, value) => pub.author.username?.toLowerCase() === value.toLowerCase(),
+    selects: isXProfilePublication,
   },
 ];
 

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -67,9 +67,10 @@ export type SocialPublication = {
   reposted_publication_id?: null | string;
   shortcode?: string;
 
-  // Provenance do Scope (#9): qual modo/valor de coleta capturou esta publicação.
-  // Campos INTERNOS ao store — o exporter v3 NÃO os inclui, então permanecem
-  // opcionais e fora do golden-master.
+  // Provenance do Scope (#9) — RESERVADO para o v4. A Provenance interna ATIVA vive em
+  // BackgroundStore.provenance (mapa por publicação), de propósito fora da publicação,
+  // para nunca poder vazar no export v3 (byte-compat). Estes campos ficam como interface
+  // futura: quando o v4 ligar, o exporter os preenche a partir do mapa.
   scope_mode?: string;
   scope_value?: string;
 };
@@ -239,6 +240,11 @@ export type LinkedInStore = NormalizedStore & {
 
 // Main store ----------------------------------------------------------------
 
+// Provenance do Scope (#9): para cada publicação capturada, registra QUAL modo de coleta
+// (profile/…) e QUAL valor (handle/perfil) a trouxe. Mapa INTERNO — nunca é lido por
+// nenhum buildPlatformData*, então é impossível vazar no export v3.
+export type ScopeProvenance = { mode: string; value: string };
+
 export type BackgroundStore = {
   activeProvider: null | SocialProvider;
   archivedEndpoints: Record<string, EndpointStore>;
@@ -257,6 +263,9 @@ export type BackgroundStore = {
     instagram: InstagramStore;
     linkedin: LinkedInStore;
   };
+
+  // Provenance por publicação, chaveada por publicationKey(provider, id). Ver ScopeProvenance.
+  provenance: Partial<Record<SocialProvider, Record<string, ScopeProvenance>>>;
 };
 
 // Export v3 ------------------------------------------------------------------

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -151,6 +151,19 @@ export type RawPayloadsResponse = {
   endpoints: Record<string, EndpointStore>;
 };
 
+// Collection Target (#9): o popup pergunta ao background qual alvo a URL da aba ativa
+// sugere, via o detectFromPage do scopeModes.profile do provider.
+export type DetectTargetMessage = {
+  action: "DETECT_TARGET";
+  pageUrl: string;
+  provider: SocialProvider;
+};
+
+export type DetectTargetResponse = {
+  mode: string;
+  target: null | string;
+};
+
 export type RuntimeMessage =
   | CapturedPayloadMessage
   | GraphqlCapturedMessage
@@ -171,7 +184,8 @@ export type RuntimeMessage =
   | GetAllSummaryMessage
   | SetHandlesMessage
   | GetHandlesMessage
-  | GetRawPayloadsMessage;
+  | GetRawPayloadsMessage
+  | DetectTargetMessage;
 
 export type PageCapturedMessage = {
   endpoint: string;

--- a/test/provenance.test.ts
+++ b/test/provenance.test.ts
@@ -114,3 +114,23 @@ describe("scope provenance (#9) — gravada na captura", () => {
     }
   });
 });
+
+describe("scope collection target (#9) — DETECT_TARGET", () => {
+  test("detecta o alvo da URL de um perfil (X)", () => {
+    const res = sendTo(createStore())({
+      action: "DETECT_TARGET",
+      provider: "x",
+      pageUrl: "https://x.com/He4rtDevs",
+    });
+    expect(res).toEqual({ mode: "profile", target: "He4rtDevs" });
+  });
+
+  test("retorna target null em URL que não é perfil (Instagram)", () => {
+    const res = sendTo(createStore())({
+      action: "DETECT_TARGET",
+      provider: "instagram",
+      pageUrl: "https://www.instagram.com/p/ABC123/",
+    });
+    expect(res).toEqual({ mode: "profile", target: null });
+  });
+});

--- a/test/provenance.test.ts
+++ b/test/provenance.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { createStore } from "../src/background/controller";
+import { recordProvenance } from "../src/background/store";
+import { publicationKey } from "../src/providers/shared/utils";
+
+// Provenance do Scope (#9): mapa interno store.provenance — registra qual modo/valor de
+// coleta trouxe cada publicação. NUNCA é exportado no v3 (o golden-master garante isso
+// nos testes por-provider abaixo, conforme cada captura passa a gravar a Provenance).
+
+describe("scope provenance (#9) — infra do mapa interno", () => {
+  test("createStore inicializa provenance vazio", () => {
+    const store = createStore();
+    expect(store.provenance).toEqual({});
+  });
+
+  test("recordProvenance grava por publicationKey(provider, id)", () => {
+    const store = createStore();
+    recordProvenance(store, "x", "123", "profile", "He4rtDevs");
+    expect(store.provenance.x?.[publicationKey("x", "123")]).toEqual({
+      mode: "profile",
+      value: "He4rtDevs",
+    });
+  });
+
+  test("recordProvenance acumula entradas independentes por provider", () => {
+    const store = createStore();
+    recordProvenance(store, "x", "1", "profile", "He4rtDevs");
+    recordProvenance(store, "instagram", "2", "profile", "he4rtdevs");
+    expect(Object.keys(store.provenance.x ?? {})).toHaveLength(1);
+    expect(store.provenance.instagram?.[publicationKey("instagram", "2")]?.value).toBe("he4rtdevs");
+  });
+});

--- a/test/provenance.test.ts
+++ b/test/provenance.test.ts
@@ -3,6 +3,7 @@ import { createStore, handleRuntimeMessage } from "../src/background/controller"
 import { recordProvenance } from "../src/background/store";
 import { publicationKey } from "../src/providers/shared/utils";
 import type { BackgroundStore } from "../src/shared/domain";
+import { instagramFeedPayload } from "./fixtures/instagram-payloads";
 import { userTweetsPayload } from "./fixtures/twitter-payloads";
 
 // Mini-harness: envia mensagens ao controller com contexto no-op.
@@ -55,5 +56,41 @@ describe("scope provenance (#9) — gravada na captura", () => {
     for (const p of Object.values(entries)) {
       expect(p).toEqual({ mode: "profile", value: "He4rtDevs" });
     }
+  });
+
+  test("Instagram: capturar feed do perfil rastreado grava Provenance", () => {
+    const store = createStore();
+    const send = sendTo(store);
+    send({ action: "SET_HANDLE", handle: "he4rtdevs" });
+    send({
+      action: "CAPTURED_PAYLOAD",
+      provider: "instagram",
+      endpoint: "InstagramFeedTimeline",
+      payload: instagramFeedPayload,
+      timestamp: "2026-05-20T13:00:00.000Z",
+      pageUrl: "https://www.instagram.com/",
+    });
+    const entries = store.provenance.instagram ?? {};
+    expect(Object.keys(entries).length).toBeGreaterThan(0);
+    for (const p of Object.values(entries)) {
+      expect(p).toEqual({ mode: "profile", value: "he4rtdevs" });
+    }
+  });
+
+  test("Provenance NUNCA vaza no export v3 (sem scope_mode/scope_value no JSON)", () => {
+    const store = createStore();
+    const send = sendTo(store);
+    send({ action: "SET_HANDLE", handle: "he4rtdevs" });
+    send({
+      action: "CAPTURED_PAYLOAD",
+      provider: "instagram",
+      endpoint: "InstagramFeedTimeline",
+      payload: instagramFeedPayload,
+      timestamp: "2026-05-20T13:00:00.000Z",
+      pageUrl: "https://www.instagram.com/",
+    });
+    const json = JSON.stringify(send({ action: "GET_EXPORT" }));
+    expect(json).not.toContain("scope_mode");
+    expect(json).not.toContain("scope_value");
   });
 });

--- a/test/provenance.test.ts
+++ b/test/provenance.test.ts
@@ -4,6 +4,7 @@ import { recordProvenance } from "../src/background/store";
 import { publicationKey } from "../src/providers/shared/utils";
 import type { BackgroundStore } from "../src/shared/domain";
 import { instagramFeedPayload } from "./fixtures/instagram-payloads";
+import { linkedinFeedPayload } from "./fixtures/linkedin-payloads";
 import { userTweetsPayload } from "./fixtures/twitter-payloads";
 
 // Mini-harness: envia mensagens ao controller com contexto no-op.
@@ -92,5 +93,24 @@ describe("scope provenance (#9) — gravada na captura", () => {
     const json = JSON.stringify(send({ action: "GET_EXPORT" }));
     expect(json).not.toContain("scope_mode");
     expect(json).not.toContain("scope_value");
+  });
+
+  test("LinkedIn: capturar feed do perfil rastreado grava Provenance", () => {
+    const store = createStore();
+    const send = sendTo(store);
+    send({ action: "SET_HANDLE", handle: "He4rt Developers", provider: "linkedin" });
+    send({
+      action: "CAPTURED_PAYLOAD",
+      provider: "linkedin",
+      endpoint: "feedDashOrganizationalPageUpdates",
+      payload: linkedinFeedPayload,
+      timestamp: "2026-05-20T14:00:00.000Z",
+      pageUrl: "https://www.linkedin.com/company/he4rt/",
+    });
+    const entries = store.provenance.linkedin ?? {};
+    expect(Object.keys(entries).length).toBeGreaterThan(0);
+    for (const p of Object.values(entries)) {
+      expect(p).toEqual({ mode: "profile", value: "He4rt Developers" });
+    }
   });
 });

--- a/test/provenance.test.ts
+++ b/test/provenance.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { createStore } from "../src/background/controller";
+import { createStore, handleRuntimeMessage } from "../src/background/controller";
 import { recordProvenance } from "../src/background/store";
 import { publicationKey } from "../src/providers/shared/utils";
+import type { BackgroundStore } from "../src/shared/domain";
+import { userTweetsPayload } from "./fixtures/twitter-payloads";
+
+// Mini-harness: envia mensagens ao controller com contexto no-op.
+const sendTo = (store: BackgroundStore) => (req: any) =>
+  handleRuntimeMessage(store, req, { log: () => {}, persistHandle: () => {} });
 
 // Provenance do Scope (#9): mapa interno store.provenance — registra qual modo/valor de
 // coleta trouxe cada publicação. NUNCA é exportado no v3 (o golden-master garante isso
@@ -28,5 +34,26 @@ describe("scope provenance (#9) — infra do mapa interno", () => {
     recordProvenance(store, "instagram", "2", "profile", "he4rtdevs");
     expect(Object.keys(store.provenance.x ?? {})).toHaveLength(1);
     expect(store.provenance.instagram?.[publicationKey("instagram", "2")]?.value).toBe("he4rtdevs");
+  });
+});
+
+describe("scope provenance (#9) — gravada na captura", () => {
+  test("X: capturar UserTweets do perfil rastreado grava {mode:profile, value:handle}", () => {
+    const store = createStore();
+    const send = sendTo(store);
+    send({ action: "SET_HANDLE", handle: "He4rtDevs" });
+    send({
+      action: "CAPTURED_PAYLOAD",
+      provider: "x",
+      endpoint: "UserTweets",
+      payload: userTweetsPayload,
+      timestamp: "2026-05-20T12:00:00.000Z",
+      pageUrl: "https://x.com/He4rtDevs",
+    });
+    const entries = store.provenance.x ?? {};
+    expect(Object.keys(entries).length).toBeGreaterThan(0);
+    for (const p of Object.values(entries)) {
+      expect(p).toEqual({ mode: "profile", value: "He4rtDevs" });
+    }
   });
 });

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -114,3 +114,45 @@ describe("scope 'profile' selects() — organization name substring (LinkedIn)",
     expect(mode.selects(pub, "Other Company")).toBe(false);
   });
 });
+
+describe("scope 'profile' detectFromPage — extrai o alvo da URL (X / Instagram)", () => {
+  const xProfile = profileMode(xScopeModes);
+  const igProfile = profileMode(instagramScopeModes);
+
+  test("X e Instagram declaram detectFromPage", () => {
+    expect(typeof xProfile.detectFromPage).toBe("function");
+    expect(typeof igProfile.detectFromPage).toBe("function");
+  });
+
+  test("X: detecta o handle em x.com/<handle>", () => {
+    expect(xProfile.detectFromPage?.("https://x.com/He4rtDevs")).toBe("He4rtDevs");
+    expect(xProfile.detectFromPage?.("https://twitter.com/He4rtDevs/")).toBe("He4rtDevs");
+  });
+
+  test("X: retorna null para URLs que não são perfil", () => {
+    for (const url of [
+      "https://x.com/home",
+      "https://x.com/explore",
+      "https://x.com/search?q=he4rt",
+      "https://x.com/He4rtDevs/status/100",
+      "https://x.com/i/timeline",
+    ]) {
+      expect(xProfile.detectFromPage?.(url)).toBeNull();
+    }
+  });
+
+  test("Instagram: detecta o username em instagram.com/<username>", () => {
+    expect(igProfile.detectFromPage?.("https://www.instagram.com/he4rtdevs/")).toBe("he4rtdevs");
+  });
+
+  test("Instagram: retorna null para posts/reels/explore/stories", () => {
+    for (const url of [
+      "https://www.instagram.com/p/ABC123/",
+      "https://www.instagram.com/reel/REEL456/",
+      "https://www.instagram.com/explore/",
+      "https://www.instagram.com/stories/he4rt/",
+    ]) {
+      expect(igProfile.detectFromPage?.(url)).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## O que muda

Torna **operante** o modo de Scope `profile` (o motivo nº2 do refactor de providers): o filtro de conteúdo deixa de ser hardcoded e passa a usar a MESMA predicate do `selects()` declarado, a Provenance é gravada num mapa interno, `detectFromPage` extrai o alvo da URL, e o popup ganha um banner de Collection Target com auto-sugestão.

Fatia #9, escopo **profile-only** (hashtag fica para outra fatia).

## Fatias (6 commits)

- **#9.1** `store.provenance` (mapa interno) + helper `recordProvenance` — byte-safe por construção (nunca lido por `buildPlatformData*`).
- **#9.2 / #9.3** X e Instagram: filtro = `selects()` do modo profile (predicate única, DRY) + grava Provenance. O IG preserva o `!handle ||` fora do predicate.
- **#9.4** LinkedIn: grava Provenance; o filtro (name OU headerText) permanece no parser (`selects()` não tem o headerText).
- **#9.5** `detectFromPage(profile)` para X e Instagram (extrai o handle da URL do perfil; status/reel/search/explore → null).
- **#9.6** Infra `DETECT_TARGET` (`scopeModes` no facet + handler) + UI de Collection Target no popup (banner com o perfil detectado da aba ativa + botão "Rastrear").

## Invariante preservada

Export v3 **byte-idêntico** — garantido pelo golden-master + uma guarda explícita ("o JSON exportado não contém `scope_mode`/`scope_value`"). Os campos `scope_mode`/`scope_value` de `SocialPublication` ficam reservados para o v4.

## Gates

- `bun test` → **51 pass / 0 fail / 3 snapshots** (era 37; +14: provenance, detectFromPage, DETECT_TARGET)
- `bun run typecheck` → **0**
- `bun run build` → ok

## ⚠️ Validação pendente (browser)

A **UI** de Collection Target (#9.6) é o único ponto que exige validação visual no Chrome: carregar `dist/chrome`, abrir um perfil de X/Instagram e conferir o banner *"Perfil detectado: … [Rastrear]"*. A infra (`DETECT_TARGET`) é coberta por teste.

## Fora desta fatia

- Modo **hashtag**; reescrita da captura do LinkedIn; `detectFromPage` do LinkedIn (slug ≠ nome de tracking); persistir a Provenance no snapshot de sessão.
