### PR TITLE
feat: provider devto

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,9 +51,16 @@ A ligação de um Engagement/Comment à Publication (ou Tracked Account) que ele
 **Provenance**:
 O carimbo em cada item normalizado dizendo de qual Scope (`mode` + `value`) ele veio; consumido pelo scoring do He4rt Hub.
 
+**Passive Capture**:
+O mecanismo de coleta original: a extensão **só observa** o que a página já carrega (intercepta fetch/XHR, lê SSR/DOM) enquanto você navega. Nenhum request parte de nós. É o modelo de X, Instagram e LinkedIn.
+_Avoid_: scraping (passivo não raspa agressivamente)
+
 **Active Fetch**:
-O **aprofundamento on-demand** de uma Publication já descoberta: o background **origina** requisições credenciadas (replay) para colher os Engagements/contadores que a captura **passiva** não trouxe (ex.: a busca descobre o post mas as reações vêm em streams preguiçosos). É **opt-in**, dosado (dry-run por padrão, volume limitado) e sujeito a ToS — distinto da captura passiva, que só observa o que a página já carrega.
-_Avoid_: scraping, crawl, automação de cliques
+Mecanismo de coleta em que a extensão **origina** requests a partir do background (service worker) — usando credenciais guardadas (**api-key**) ou o cookie de sessão vivo — em vez de esperar a navegação. Dois usos: (a) **aprofundar** on-demand uma Publication já descoberta, colhendo os Engagements/contadores que a captura passiva não trouxe (ex.: a busca do LinkedIn acha o post, mas as reações vêm em streams preguiçosos); (b) ser o **mecanismo primário** de um provider sem captura passiva (ex.: dev.to). Disparado on-demand (botão "Coletar") e por AFK (`chrome.alarms`, diário, só na analytics). É **opt-in**, dosado (dry-run por padrão, volume limitado) e sujeito a ToS — distinto da captura passiva, que só observa o que a página já carrega.
+_Avoid_: scraping, crawl, sync, automação de cliques
+
+**Background-only Provider**:
+Um Provider que coleta **apenas** por Active Fetch e portanto **não injeta content scripts** — declara `hostPermissions` (pro fetch credenciado) mas não `matches`. O dev.to é o primeiro.
 
 **Publication URN / Thread**:
 No LinkedIn, uma Publication tem **mais de uma identidade**: a `activity` (o *wrapper* que a busca/feed descobre) e o **thread** (`ugcPost`/`share`, a peça por baixo). Os **Engagements** são endereçados pelo **thread**, não pela activity — então descobrir a Publication (activity) **não basta** para colher engajamento; é preciso **resolver** `activity → thread`.
@@ -86,4 +93,5 @@ _Avoid_: id do post, postId (são ambíguos entre as duas identidades)
 - **Publication-centric (código) vs Engagement-centric (produto)** — o código atual trata `SocialPublication` como cidadão de primeira classe e deriva engajamentos; o produto (README + ADR-0001) quer o inverso. **Resolvido (arquitetura):** _Scope seleciona Publications; Engagements seguem por Binding e são o sinal exportado pro Hub._ O store guarda os dois, mas o produto lê pelo Engagement.
 - **Handle vs Profile** — o código conflata em `trackedHandle` (string) e `trackedProfiles` (metadados). Resolvido aqui: **Handle** é a identidade-string usada pra escopar; **Profile** são os metadados capturados.
 - **"reply"** — usado pra dois conceitos: um subtipo de **Publication** (tweet de resposta) e um **Comment**. Manter os dois sentidos explícitos.
+- **Passivo vs Ativo** — a regra de ouro do projeto (CLAUDE.md) cravava *"intercepta passivamente… não automatiza"*. O provider **dev.to** introduz **Active Fetch** (api-key na analytics oficial + cookie vivo em `/reactions`, on-demand + AFK diário só na analytics). **Resolução:** a regra passa a ser *"passivo por padrão; Active Fetch é exceção explícita, declarada por provider, GET a endpoints da própria conta logada"*. dev.to é **Background-only Provider** (sem content script). Ver ADR-0003 (a decisão e seus trade-offs de ToS/segurança).
 - **activity vs thread (ugcPost) no LinkedIn** — a busca/feed entrega a `activity` URN, mas os **Engagements** são endereçados pelo **thread** (`ugcPost`/`share`). Pedir reactions/comments/reposts pela `activity` retorna **vazio** (HTTP 200, 0 itens) — não erro, o que engana. **Resolvido (entendimento):** _o **Active Fetch** precisa de um passo de **resolve** `activity→thread` antes do fan-out; a `activity` identifica a Publication, o `thread` endereça os Engagements._ Detalhes e plano em [`docs/specs/2026-06-05-l3-replay-findings.md`](docs/specs/2026-06-05-l3-replay-findings.md).

--- a/docs/adr/0002-providers-plugaveis-ports-and-adapters.md
+++ b/docs/adr/0002-providers-plugaveis-ports-and-adapters.md
@@ -46,7 +46,7 @@ Decisões específicas:
 - **Federação total** (cada provider com seu próprio domínio) — rejeitada: o domínio de feed é comum o bastante (post/comentário/engajamento) e a federação perderia os rollups cross-rede que o produto quer (engajadores únicos entre redes).
 - **Tipo único "gordo"** sem `extra` — rejeitada: é exatamente o estado atual. Mapa de `metrics` + `extra` tipado na borda preserva fidelidade sem poluir o core.
 - **Entregar o v4 de eventos agora** — adiada: quebra a ingestão do Hub e é decisão de produto, não de refactor interno. Fica pronto-para-ligar.
-- **`activeFetch`** (extensão disparando requests) — rejeitada por ora: navegação ativa é papel do Playwright (ADR-0001). O catálogo de captura é extensível se isso mudar.
+- **`activeFetch`** (extensão disparando requests) — rejeitada por ora: navegação ativa é papel do Playwright (ADR-0001). O catálogo de captura é extensível se isso mudar. **→ Revisto no [ADR-0003](./0003-active-fetch-provider-devto.md):** o provider dev.to abre essa porta de forma contida (GET à própria conta logada, on-demand + AFK só na analytics).
 - **Big-bang rewrite** — rejeitado: o strangler dá diff revisável por fase e permite bissecar regressões.
 - **Auto-discovery de providers** — rejeitado: registry explícito é tipado e tree-shakeable; com um punhado de redes, auto-discovery só agrega magia.
 

--- a/docs/adr/0003-active-fetch-provider-devto.md
+++ b/docs/adr/0003-active-fetch-provider-devto.md
@@ -1,0 +1,100 @@
+# ADR 0003: Active Fetch — coleta que origina requests (provider dev.to)
+
+## Status
+
+Aceito. **Emenda parcial ao [ADR-0002](./0002-providers-plugaveis-ports-and-adapters.md)**, que
+cravou *"a captura é passiva"* e **rejeitou `activeFetch`** ("navegação ativa é papel do
+Playwright… o catálogo de captura é extensível se isso mudar"). Isso mudou — ver Contexto.
+A regra de ouro do projeto passa de *"só observa"* para *"passivo por padrão; Active Fetch é
+exceção explícita, declarada por provider"*.
+
+## Contexto
+
+Os três providers de hoje (X, Instagram, LinkedIn) coletam por **Passive Capture**: a extensão
+só observa o que a página já carrega enquanto você navega. Esse modelo não alcança o **dev.to**,
+porque os dados que importam **não estão na navegação normal**:
+
+1. **Performance do autor** (page_views, read_time, follows, breakdown de reações por dia) só
+   sai do endpoint oficial `GET /api/analytics/historical?article_id=`, autenticado por
+   **api-key** e **escopado à conta dona da key**. A página `/stats` apenas *renderiza* o que
+   esse endpoint devolve via fetch — não há SSR/`<script>` estável pra raspar passivamente, e
+   abrir `/stats` de cada artigo à mão não escala.
+2. **Engagement** ("quem reagiu" — Actor + tipo + data, o sinal que o `CONTEXT.md` chama de mais
+   valioso) só existe na lista de Reactions History; a forma estruturada é a rota interna
+   `GET /reactions?article_id=`, autenticada pela **sessão** (cookie vivo).
+
+Ambas exigem **originar** requests a partir do background. O ADR-0002 destinava navegação ativa
+ao Playwright (ADR-0001), mas para o dev.to isso seria infra desproporcional: a api-key e o
+cookie de sessão **já vivem no navegador logado do usuário**. Levantar Playwright pra reusar uma
+credencial que a extensão já tem em mãos não se paga. O ADR-0002 previu essa porta ("se isso
+mudar") — este ADR a abre, de forma contida.
+
+## Decisão
+
+Introduzir **Active Fetch** como um **seam de primeira classe**, sem inchar as camadas genéricas
+nem mexer no contrato passivo existente.
+
+```
+ networkIntercept  MAIN       reage ao tráfego da página      ┐
+ ssr/code/scrape   ISOLATED   lê o que a página renderizou    ├─ Passive Capture (inalterado)
+ ── NOVO ──                                                   ┘
+ activeFetch       BACKGROUND ORIGINA o request (service worker) ── Active Fetch
+```
+
+- **Faceta `activeFetch` declarada pelo provider.** Como toda captura no ADR-0002, é
+  declarativa: o provider DECLARA seus endpoints, o esquema de auth de cada um
+  (`api-key` no header | `cookie` via `credentials:"include"`) e como enumerar os alvos
+  (dev.to: `GET /api/articles/me`). Registrada num registry próprio, paralelo a
+  `CAPTURE_FACETS`/`BACKGROUND_PROVIDERS`. As camadas genéricas continuam sem `if` por rede.
+- **O resultado entra no MESMO `processCapture(store, capture)`.** Um Active Fetch é só mais uma
+  *origem de payload*: produz um envelope de captura sintético que o `parser`/`index` do provider
+  normaliza igual a uma captura passiva. Parser, store e export ficam **idênticos em forma** — o
+  golden-master v3 nem sente (dev.to é aditivo: nova chave em `per_platform`).
+- **Gatilho on-demand + AFK assimétrico.** O botão "Coletar" dispara tudo com o usuário presente.
+  Um `chrome.alarms` **diário** atualiza **só a analytics por api-key** (AFK-safe, não depende de
+  sessão). O Engagement por `/reactions` (cookie) **não** roda no AFK — falha graciosamente quando
+  a sessão expira; a analytics segue.
+- **dev.to é um Background-only Provider.** Coleta só por Active Fetch, então **não injeta content
+  script**. `ProviderMeta` passa a separar `matches` (gera content scripts) de `hostPermissions`
+  (gera permissão de fetch); dev.to declara só `hostPermissions`.
+- **Credencial.** A api-key é digitada na aba Config e persiste em `chrome.storage.local`
+  (mesmo mecanismo dos handles). É um **segredo em texto puro no disco** — aceito para uma
+  ferramenta pessoal de membro; registrado como risco conhecido (ver Consequências).
+- **Escopo single-tenant.** v1 cobre o **usuário logado** (a conta dona da api-key + cookies).
+  "Todos os membros" é multi-credencial e fica fora desta decisão.
+
+## Alternativas consideradas
+
+- **Manter passivo + abrir cada `/stats` à mão** — rejeitada: não escala, e nem alcança a
+  analytics (que vem por fetch da própria página, sem SSR raspável estável).
+- **Fazer o Active Fetch no Playwright/OpenClaw (ADR-0001)** — rejeitada por ora: a api-key e o
+  cookie já estão no navegador logado; levantar Playwright só pra reusá-los é infra
+  desproporcional. Continua sendo o caminho se virar multi-tenant/headless.
+- **Capturar e persistir headers de sessão pra replay** (o pedido original) — rejeitada: no MV3
+  um `fetch` credenciado reanexa o cookie httpOnly automaticamente enquanto logado; persistir
+  header só seria preciso se houvesse um header não-cookie obrigatório (CSRF/anti-bot), que não
+  se confirmou. Construir o mínimo.
+- **Subsistema `src/sync/` dev.to-específico** — rejeitada: reintroduziria código por-rede num
+  lugar novo, ferindo a regra do ADR-0002 ("camadas genéricas não conhecem redes").
+- **AFK pleno nas duas fontes** — rejeitada: o Engagement depende de sessão e falharia em
+  silêncio no background; só a analytics é honestamente AFK.
+
+## Consequências
+
+**Positivas**
+- dev.to entra como **1 pasta + registros**, igual aos outros, reusando `processCapture`/parser/
+  store/export. O export v3 permanece byte-compatível (aditivo).
+- Active Fetch fica **declarativo e contido**: GET, endpoints da própria conta logada, on-demand
+  por padrão e AFK só na analytics — a exceção à regra de ouro é estreita e auditável.
+- Desacoplar `matches`↔`hostPermissions` habilita futuros providers background-only (APIs).
+
+**Negativas / custos**
+- **Postura de ToS** muda: a extensão deixa de só observar e passa a originar requests
+  autenticados. Mitigado por restringir a GET, à própria conta, e com throttle sequencial para
+  respeitar rate-limit.
+- **Segredo no disco:** a api-key em `chrome.storage.local` é texto puro, legível por quem tiver
+  acesso ao perfil/DevTools. Aceito para uso pessoal; reavaliar se a base de usuários crescer.
+- **AFK frágil para Engagement:** "quem reagiu" só atualiza on-demand ou enquanto logado — não há
+  garantia de frescor em background.
+- Surge um **scheduler no background** (enumerar → fan-out por artigo com delay) que não existia;
+  é a primeira lógica de orquestração de requests da extensão.

--- a/scripts/validate-extension.ts
+++ b/scripts/validate-extension.ts
@@ -81,7 +81,7 @@ async function validateManifest() {
   assertIncludesAll(manifest.permissions, ["storage", "unlimitedStorage"], "permissions");
   assertIncludesAll(
     manifest.host_permissions,
-    ["https://x.com/*", "https://twitter.com/*", "https://www.instagram.com/*"],
+    ["https://x.com/*", "https://twitter.com/*", "https://www.instagram.com/*", "https://dev.to/*"],
     "host_permissions",
   );
 
@@ -106,6 +106,9 @@ async function validateManifest() {
       ["https://x.com/*", "https://twitter.com/*", "https://www.instagram.com/*"],
       `${script.js.join(",")} matches`,
     );
+    if (script.matches?.includes("https://dev.to/*")) {
+      fail(`${script.js.join(",")} não deve incluir dev.to nos matches (Background-only provider)`);
+    }
   }
 
   if (manifest.side_panel?.default_path !== "panel.html") {

--- a/src/background/active-fetch-scheduler.ts
+++ b/src/background/active-fetch-scheduler.ts
@@ -1,0 +1,63 @@
+import type { ActiveFetchStatus, ActiveFetchStrategy } from "../providers/devto/active-fetch";
+
+type FetchFn = (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export async function runActiveFetch(opts: {
+  strategy: ActiveFetchStrategy;
+  apiKey: string | null;
+  mode: "onDemand" | "afk";
+  fetchFn?: FetchFn;
+  onCapture: (endpoint: string, payload: unknown) => void;
+  delayMs?: number;
+}): Promise<ActiveFetchStatus> {
+  const { strategy, apiKey, mode, fetchFn = fetch as FetchFn, onCapture, delayMs = 300 } = opts;
+
+  if (!apiKey) {
+    return { collected: 0, articles: 0, reactions: 0, apiKeyInvalid: true };
+  }
+
+  const targets = await strategy.enumerate({ apiKey });
+
+  if (targets.length === 0) {
+    return { collected: 0, articles: 0, reactions: 0 };
+  }
+
+  const requests = targets.flatMap((target) =>
+    strategy.requestsFor(target).filter((req) => mode === "onDemand" || req.afkSafe),
+  );
+
+  let collected = 0;
+  let reactionCount = 0;
+  let sessionNeeded = false;
+
+  for (const [i, req] of requests.entries()) {
+    if (i > 0) await sleep(delayMs);
+    try {
+      const fetchOpts: RequestInit =
+        req.auth === "api-key"
+          ? { headers: { "api-key": apiKey } }
+          : { credentials: "include" };
+      const res = await fetchFn(req.url, fetchOpts);
+      if (res.status === 401 || res.status === 403) {
+        sessionNeeded = true;
+        continue;
+      }
+      const payload = await res.json();
+      onCapture(req.endpoint, payload);
+      collected++;
+      if (req.endpoint === "reactions") reactionCount++;
+    } catch {
+      // rede falhou neste request individual — segue para o próximo
+    }
+  }
+
+  const status: ActiveFetchStatus = {
+    collected,
+    articles: targets.length,
+    reactions: reactionCount,
+  };
+  if (sessionNeeded) status.sessionNeeded = true;
+  return status;
+}

--- a/src/background/active-fetch-scheduler.ts
+++ b/src/background/active-fetch-scheduler.ts
@@ -9,7 +9,7 @@ export async function runActiveFetch(opts: {
   apiKey: string | null;
   mode: "onDemand" | "afk";
   fetchFn?: FetchFn;
-  onCapture: (endpoint: string, payload: unknown) => void;
+  onCapture: (endpoint: string, payload: unknown, url: string) => void;
   delayMs?: number;
 }): Promise<ActiveFetchStatus> {
   const { strategy, apiKey, mode, fetchFn = fetch as FetchFn, onCapture, delayMs = 300 } = opts;
@@ -36,16 +36,15 @@ export async function runActiveFetch(opts: {
     if (i > 0) await sleep(delayMs);
     try {
       const fetchOpts: RequestInit =
-        req.auth === "api-key"
-          ? { headers: { "api-key": apiKey } }
-          : { credentials: "include" };
+        req.auth === "api-key" ? { headers: { "api-key": apiKey } } : { credentials: "include" };
       const res = await fetchFn(req.url, fetchOpts);
       if (res.status === 401 || res.status === 403) {
         sessionNeeded = true;
         continue;
       }
+      if (!res.ok) continue;
       const payload = await res.json();
-      onCapture(req.endpoint, payload);
+      onCapture(req.endpoint, payload, req.url);
       collected++;
       if (req.endpoint === "reactions") reactionCount++;
     } catch {

--- a/src/background/controller.ts
+++ b/src/background/controller.ts
@@ -15,10 +15,12 @@ import {
 } from "../providers/linkedin";
 import { getCalibration, isCalibrated } from "../providers/linkedin/active-fetch/calibration";
 import { linkedinActiveFetchFacet } from "../providers/linkedin/active-fetch/facet";
+import { devtoProvider } from "../providers/devto";
 import { publicationKey } from "../providers/shared/utils";
 import { buildPlatformDataX, computeSummaryX, xProvider } from "../providers/x";
 import type {
   BackgroundStore,
+  DevToStore,
   ExportJSON,
   ExportV3Meta,
   InstagramStore,
@@ -84,6 +86,17 @@ function emptyLinkedInStore(): LinkedInStore {
   };
 }
 
+function emptyDevToStore(): DevToStore {
+  return {
+    publications: {},
+    commentsByPublication: {},
+    engagementsByPublication: {},
+    extra: {
+      analytics: {},
+    },
+  };
+}
+
 export function createStore(trackedHandle = ""): BackgroundStore {
   return {
     activeProvider: null,
@@ -94,6 +107,7 @@ export function createStore(trackedHandle = ""): BackgroundStore {
       x: emptyXStore(),
       instagram: emptyInstagramStore(),
       linkedin: emptyLinkedInStore(),
+      devto: emptyDevToStore(),
     },
     lastUpdated: null,
     nextCaptureOrder: 1,
@@ -153,6 +167,7 @@ const BACKGROUND_PROVIDERS: Record<SocialProvider, BackgroundProviderFacet> = {
   x: xProvider,
   instagram: instagramProvider,
   linkedin: linkedinProvider,
+  devto: devtoProvider,
 };
 
 // Registro PARALELO a BACKGROUND_PROVIDERS para o caminho ATIVO (Active Fetch / L3).
@@ -200,6 +215,7 @@ function clearNormalizedData(store: BackgroundStore) {
   const linkedinAccountInfo = store.platforms.linkedin.extra.accountInfo;
   store.platforms.linkedin = emptyLinkedInStore();
   store.platforms.linkedin.extra.accountInfo = linkedinAccountInfo;
+  store.platforms.devto = emptyDevToStore();
 
   store.trackedProfiles = {};
   store.provenance = {};

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,5 +1,7 @@
 import type { BackgroundStore, EndpointStore, SocialProvider } from "../shared/domain";
 import type { RuntimeMessage } from "../shared/messages";
+import { getActiveFetchStrategy } from "../providers/active-fetch-registry";
+import { runActiveFetch } from "./active-fetch-scheduler";
 import { createStore, handleRuntimeMessage } from "./controller";
 
 const LOCAL_KEYS = {
@@ -11,6 +13,35 @@ const LOCAL_KEYS = {
 const SESSION_KEY = "he4rt_platforms";
 
 const store = createStore();
+
+if (chrome.alarms) {
+  chrome.runtime.onInstalled.addListener(() => {
+    chrome.alarms.create("devto-afk", { periodInMinutes: 1440 });
+  });
+
+  chrome.alarms.onAlarm.addListener(async (alarm) => {
+    if (alarm.name !== "devto-afk") return;
+    const strategy = getActiveFetchStrategy("devto");
+    if (!strategy) return;
+    const result = await chrome.storage.local.get("devtoApiKey");
+    const apiKey = (result.devtoApiKey as string | undefined) ?? null;
+    await runActiveFetch({
+      strategy,
+      apiKey,
+      mode: "afk",
+      onCapture: (endpoint, payload) => {
+        handleRuntimeMessage(store, {
+          action: "CAPTURED_PAYLOAD",
+          provider: "devto",
+          endpoint,
+          payload,
+          pageUrl: "https://dev.to",
+          timestamp: new Date().toISOString(),
+        });
+      },
+    });
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Hydration: load from both storage areas
@@ -130,6 +161,36 @@ chrome.runtime.onMessage.addListener((request: RuntimeMessage, _sender, sendResp
       ? chrome.storage.local.set({ devtoApiKey: apiKey })
       : chrome.storage.local.remove("devtoApiKey");
     op.then(() => sendResponse({ ok: true }));
+    return true;
+  }
+
+  if (request.action === "RUN_ACTIVE_FETCH") {
+    const provider = request.provider;
+    chrome.storage.local.get("devtoApiKey").then(async (result) => {
+      const apiKey = (result.devtoApiKey as string | undefined) ?? null;
+      const strategy = getActiveFetchStrategy(provider);
+      if (!strategy) {
+        sendResponse({ collected: 0, articles: 0, reactions: 0 });
+        return;
+      }
+      const status = await runActiveFetch({
+        strategy,
+        apiKey,
+        mode: "onDemand",
+        onCapture: (endpoint, payload) => {
+          handleRuntimeMessage(store, {
+            action: "CAPTURED_PAYLOAD",
+            provider,
+            endpoint,
+            payload,
+            pageUrl: "https://dev.to",
+            timestamp: new Date().toISOString(),
+          });
+        },
+      });
+      persistSession();
+      sendResponse(status);
+    });
     return true;
   }
 

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -117,6 +117,22 @@ function notifyStoreUpdated() {
 // ---------------------------------------------------------------------------
 
 chrome.runtime.onMessage.addListener((request: RuntimeMessage, _sender, sendResponse) => {
+  if (request.action === "GET_DEVTO_API_KEY") {
+    chrome.storage.local.get("devtoApiKey").then((result) => {
+      sendResponse({ apiKey: (result.devtoApiKey as string | undefined) ?? null });
+    });
+    return true;
+  }
+
+  if (request.action === "SET_DEVTO_API_KEY") {
+    const { apiKey } = request;
+    const op = apiKey
+      ? chrome.storage.local.set({ devtoApiKey: apiKey })
+      : chrome.storage.local.remove("devtoApiKey");
+    op.then(() => sendResponse({ ok: true }));
+    return true;
+  }
+
   hydration
     .then(() => {
       // handleRuntimeMessage pode devolver um valor síncrono OU uma Promise (ex.:

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,6 +1,6 @@
+import { getActiveFetchStrategy } from "../providers/active-fetch-registry";
 import type { BackgroundStore, EndpointStore, SocialProvider } from "../shared/domain";
 import type { RuntimeMessage } from "../shared/messages";
-import { getActiveFetchStrategy } from "../providers/active-fetch-registry";
 import { runActiveFetch } from "./active-fetch-scheduler";
 import { createStore, handleRuntimeMessage } from "./controller";
 
@@ -23,23 +23,26 @@ if (chrome.alarms) {
     if (alarm.name !== "devto-afk") return;
     const strategy = getActiveFetchStrategy("devto");
     if (!strategy) return;
+    await hydration;
     const result = await chrome.storage.local.get("devtoApiKey");
     const apiKey = (result.devtoApiKey as string | undefined) ?? null;
     await runActiveFetch({
       strategy,
       apiKey,
       mode: "afk",
-      onCapture: (endpoint, payload) => {
+      onCapture: (endpoint, payload, url) => {
         handleRuntimeMessage(store, {
           action: "CAPTURED_PAYLOAD",
           provider: "devto",
           endpoint,
           payload,
+          url,
           pageUrl: "https://dev.to",
           timestamp: new Date().toISOString(),
         });
       },
     });
+    persistSession();
   });
 }
 
@@ -74,6 +77,7 @@ async function hydrate() {
     if (s.x) Object.assign(store.platforms.x, s.x);
     if (s.instagram) Object.assign(store.platforms.instagram, s.instagram);
     if (s.linkedin) Object.assign(store.platforms.linkedin, s.linkedin);
+    if (s.devto) Object.assign(store.platforms.devto, s.devto);
   }
 
   store.lastUpdated = new Date().toISOString();
@@ -92,6 +96,7 @@ function persistSession(): Promise<void> {
     x: store.platforms.x,
     instagram: store.platforms.instagram,
     linkedin: store.platforms.linkedin,
+    devto: store.platforms.devto,
   };
   persistQueue = persistQueue
     .then(() => chrome.storage.session.set({ [SESSION_KEY]: snapshot }))
@@ -164,33 +169,36 @@ chrome.runtime.onMessage.addListener((request: RuntimeMessage, _sender, sendResp
     return true;
   }
 
-  if (request.action === "RUN_ACTIVE_FETCH") {
+  if (request.action === "RUN_ACTIVE_FETCH" && request.provider === "devto") {
     const provider = request.provider;
-    chrome.storage.local.get("devtoApiKey").then(async (result) => {
-      const apiKey = (result.devtoApiKey as string | undefined) ?? null;
-      const strategy = getActiveFetchStrategy(provider);
-      if (!strategy) {
-        sendResponse({ collected: 0, articles: 0, reactions: 0 });
-        return;
-      }
-      const status = await runActiveFetch({
-        strategy,
-        apiKey,
-        mode: "onDemand",
-        onCapture: (endpoint, payload) => {
-          handleRuntimeMessage(store, {
-            action: "CAPTURED_PAYLOAD",
-            provider,
-            endpoint,
-            payload,
-            pageUrl: "https://dev.to",
-            timestamp: new Date().toISOString(),
-          });
-        },
+    hydration
+      .then(() => chrome.storage.local.get("devtoApiKey"))
+      .then(async (result) => {
+        const apiKey = (result.devtoApiKey as string | undefined) ?? null;
+        const strategy = getActiveFetchStrategy(provider);
+        if (!strategy) {
+          sendResponse({ collected: 0, articles: 0, reactions: 0 });
+          return;
+        }
+        const status = await runActiveFetch({
+          strategy,
+          apiKey,
+          mode: "onDemand",
+          onCapture: (endpoint, payload, url) => {
+            handleRuntimeMessage(store, {
+              action: "CAPTURED_PAYLOAD",
+              provider,
+              endpoint,
+              payload,
+              url,
+              pageUrl: "https://dev.to",
+              timestamp: new Date().toISOString(),
+            });
+          },
+        });
+        persistSession();
+        sendResponse(status);
       });
-      persistSession();
-      sendResponse(status);
-    });
     return true;
   }
 

--- a/src/capture/registry.ts
+++ b/src/capture/registry.ts
@@ -29,6 +29,10 @@ export const CAPTURE_FACETS: Record<SocialProvider, CaptureFacet> = {
     ssrScriptScan: instagramSsrScriptScan,
     liveDomScrapes: [instagramVisiblePublicationsScrape, instagramVisibleCommentsScrape],
   },
+  // Background-only provider: sem estratégias de captura passiva.
+  devto: {
+    id: "devto",
+  },
 };
 
 export function captureFacetForHost(hostname: string): CaptureFacet | null {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,13 +1,16 @@
 import { PROVIDER_METAS } from "./providers/meta";
 
-// Os matches dos content scripts saem do registry de providers.
-const matches = PROVIDER_METAS.flatMap((meta) => meta.matches);
+// content_scripts só para providers com matches (não-vazios; Background-only fica de fora).
+const contentScriptMatches = PROVIDER_METAS.flatMap((meta) => meta.matches);
 
 // host_permissions = união (deduplicada) dos matches com os hostPermissions extras dos
 // providers (split do ADR-0003: alguns providers chamam endpoints via Active Fetch e
 // precisam da permissão de host além de onde injetam content script).
 const hostPermissions = [
-  ...new Set([...matches, ...PROVIDER_METAS.flatMap((meta) => meta.hostPermissions ?? [])]),
+  ...new Set([
+    ...contentScriptMatches,
+    ...PROVIDER_METAS.flatMap((meta) => meta.hostPermissions ?? []),
+  ]),
 ];
 
 const manifest = {
@@ -25,13 +28,13 @@ const manifest = {
   },
   content_scripts: [
     {
-      matches,
+      matches: contentScriptMatches,
       js: ["interceptor.js"],
       run_at: "document_start",
       world: "MAIN",
     },
     {
-      matches,
+      matches: contentScriptMatches,
       js: ["content.js"],
       run_at: "document_start",
       world: "ISOLATED",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -20,7 +20,8 @@ const manifest = {
   description: "Captura engajamento social da comunidade He4rt Developers",
   // "cookies": o SW lê o JSESSIONID (csrf) de linkedin.com para o replay credenciado do L3.
   // "sidePanel": a UI vive num side panel (substitui o popup) — clique no ícone abre o painel.
-  permissions: ["storage", "tabs", "unlimitedStorage", "cookies", "sidePanel"],
+  // "alarms": o scheduler de Active Fetch (AFK diário) acorda o SW via chrome.alarms.
+  permissions: ["storage", "tabs", "unlimitedStorage", "cookies", "sidePanel", "alarms"],
   host_permissions: hostPermissions,
   background: {
     service_worker: "background.js",

--- a/src/panel/components/ConfigPanel.tsx
+++ b/src/panel/components/ConfigPanel.tsx
@@ -1,5 +1,5 @@
-// Aba Config: perfis monitorados. Edita um rascunho local e salva via SET_HANDLES
-// (mesma ação do popup, que limpa + reprocessa no background).
+// Aba Config: perfis monitorados + api-key do dev.to. Edita um rascunho local e salva via
+// SET_HANDLES (mesma ação do popup, que limpa + reprocessa no background).
 
 import { useSignal } from "@preact/signals";
 import { useEffect } from "preact/hooks";
@@ -64,6 +64,86 @@ export function ConfigPanel() {
       >
         {saving.value ? "Salvo!" : "Salvar perfis"}
       </button>
+
+      <DevtoApiKeySection />
     </div>
+  );
+}
+
+// Seção da api-key do dev.to (Active Fetch). Não exibe a key salva — só se existe uma;
+// SET com apiKey=null remove. Portado do popup legado (Fatia 2) para o painel reativo.
+function DevtoApiKeySection() {
+  const hasKey = useSignal(false);
+  const draft = useSignal("");
+  const busy = useSignal(false);
+
+  // Descobre no mount se já há uma key guardada (o background só responde se existe).
+  useEffect(() => {
+    void send<{ apiKey: string | null } | undefined>({ action: "GET_DEVTO_API_KEY" }).then((res) => {
+      hasKey.value = res?.apiKey != null && res.apiKey !== "";
+    });
+  }, []);
+
+  async function save() {
+    const key = draft.value.trim();
+    if (!key) return;
+    busy.value = true;
+    await send({ action: "SET_DEVTO_API_KEY", apiKey: key });
+    draft.value = "";
+    hasKey.value = true;
+    busy.value = false;
+  }
+
+  async function remove() {
+    busy.value = true;
+    await send({ action: "SET_DEVTO_API_KEY", apiKey: null });
+    hasKey.value = false;
+    busy.value = false;
+  }
+
+  return (
+    <>
+      <h3 class="mb-3 mt-6 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-3">
+        dev.to
+      </h3>
+      {hasKey.value ? (
+        <div class="mb-2 flex items-center gap-2.5 rounded-xl border border-line-2 bg-card py-2 pl-3.5 pr-1.5">
+          <span class="min-w-[64px] text-xs font-semibold text-dt">api-key</span>
+          <span class="flex-1 text-xs font-medium text-ok">Key salva ✓</span>
+          <button
+            type="button"
+            onClick={() => void remove()}
+            disabled={busy.value}
+            class="rounded-lg border border-line-2 px-3 py-1.5 text-xs font-semibold text-accent transition-colors hover:border-accent disabled:opacity-60"
+          >
+            Remover
+          </button>
+        </div>
+      ) : (
+        <>
+          <div class="mb-2 flex items-center gap-2.5 rounded-xl border border-line-2 bg-card py-0.5 pl-3.5 pr-1.5">
+            <span class="min-w-[64px] text-xs font-semibold text-dt">api-key</span>
+            <input
+              type="password"
+              class="w-full bg-transparent py-2 font-mono text-xs text-ink outline-none placeholder:text-ink-3"
+              placeholder="Cole sua api-key aqui"
+              spellcheck={false}
+              value={draft.value}
+              onInput={(e) => {
+                draft.value = (e.target as HTMLInputElement).value;
+              }}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={busy.value || draft.value.trim() === ""}
+            class="mt-1 w-full rounded-lg border border-ink bg-ink px-3 py-2.5 text-xs font-semibold text-paper transition-colors hover:border-accent hover:bg-accent disabled:opacity-60"
+          >
+            Salvar
+          </button>
+        </>
+      )}
+    </>
   );
 }

--- a/src/panel/styles.css
+++ b/src/panel/styles.css
@@ -19,6 +19,7 @@
   --color-x: #1d9bf0;
   --color-ig: #d6336c;
   --color-li: #0a66c2;
+  --color-dt: #3b49df;
 
   --font-display: "Fraunces", Georgia, serif;
   --font-sans: "Hanken Grotesk", system-ui, sans-serif;

--- a/src/providers/active-fetch-registry.ts
+++ b/src/providers/active-fetch-registry.ts
@@ -1,0 +1,10 @@
+import type { ActiveFetchStrategy } from "./devto/active-fetch";
+import { devtoActiveFetchStrategy } from "./devto/active-fetch";
+
+export const ACTIVE_FETCH_REGISTRY: Record<string, ActiveFetchStrategy> = {
+  devto: devtoActiveFetchStrategy,
+};
+
+export function getActiveFetchStrategy(provider: string): ActiveFetchStrategy | null {
+  return ACTIVE_FETCH_REGISTRY[provider] ?? null;
+}

--- a/src/providers/devto/active-fetch.ts
+++ b/src/providers/devto/active-fetch.ts
@@ -32,19 +32,19 @@ export const devtoActiveFetchStrategy: ActiveFetchStrategy = {
     });
     if (!res.ok) return [];
     const articles = (await res.json()) as Array<{ id: number }>;
-    return articles.map((a) => ({ id: String(a.id), meta: a }));
+    return articles.map((a) => ({ id: String(a.id) }));
   },
   requestsFor(target) {
     return [
       {
         endpoint: "analytics",
-        url: `https://dev.to/api/analytics/historical?article_id=${target.id}`,
+        url: `https://dev.to/api/analytics/dashboard?article_id=${target.id}`,
         auth: "api-key",
         afkSafe: true,
       },
       {
         endpoint: "reactions",
-        url: `https://dev.to/api/reactions?article_id=${target.id}`,
+        url: `https://dev.to/reactions?article_id=${target.id}`,
         auth: "cookie",
         afkSafe: false,
       },

--- a/src/providers/devto/active-fetch.ts
+++ b/src/providers/devto/active-fetch.ts
@@ -1,0 +1,53 @@
+export type DevToAuth = "api-key" | "cookie";
+
+export type EnumeratedTarget = { id: string; meta?: unknown };
+
+export type ActiveFetchRequest = {
+  endpoint: string;
+  url: string;
+  auth: DevToAuth;
+  afkSafe: boolean;
+};
+
+export type ActiveFetchStrategy = {
+  kind: "activeFetch";
+  enumerate: (ctx: { apiKey: string | null }) => Promise<EnumeratedTarget[]>;
+  requestsFor: (target: EnumeratedTarget) => ActiveFetchRequest[];
+};
+
+export type ActiveFetchStatus = {
+  collected: number;
+  articles: number;
+  reactions: number;
+  sessionNeeded?: boolean;
+  apiKeyInvalid?: boolean;
+};
+
+export const devtoActiveFetchStrategy: ActiveFetchStrategy = {
+  kind: "activeFetch",
+  async enumerate({ apiKey }) {
+    if (!apiKey) return [];
+    const res = await fetch("https://dev.to/api/articles/me", {
+      headers: { "api-key": apiKey },
+    });
+    if (!res.ok) return [];
+    const articles = (await res.json()) as Array<{ id: number }>;
+    return articles.map((a) => ({ id: String(a.id), meta: a }));
+  },
+  requestsFor(target) {
+    return [
+      {
+        endpoint: "analytics",
+        url: `https://dev.to/api/analytics/historical?article_id=${target.id}`,
+        auth: "api-key",
+        afkSafe: true,
+      },
+      {
+        endpoint: "reactions",
+        url: `https://dev.to/api/reactions?article_id=${target.id}`,
+        auth: "cookie",
+        afkSafe: false,
+      },
+    ];
+  },
+};

--- a/src/providers/devto/index.ts
+++ b/src/providers/devto/index.ts
@@ -1,7 +1,28 @@
+import type { DevToStore } from "../../shared/domain";
 import type { BackgroundProviderFacet } from "../contract";
+import { publicationKey } from "../shared/utils";
+import { articleIdFromUrl, parseAnalytics, parseReactions } from "./parser";
 
 export const devtoProvider: BackgroundProviderFacet = {
   id: "devto",
-  processCapture: () => {},
+  processCapture(store, capture) {
+    if (capture.provider !== "devto") return;
+
+    const articleId = capture.url ? articleIdFromUrl(capture.url) : null;
+    if (!articleId) return;
+
+    const devtoStore = store.platforms.devto as DevToStore;
+
+    if (capture.endpoint === "analytics") {
+      const analytics = parseAnalytics(articleId, capture.payload);
+      if (analytics) {
+        devtoStore.extra.analytics[articleId] = analytics;
+      }
+    } else if (capture.endpoint === "reactions") {
+      const engagements = parseReactions(articleId, capture.payload, capture.timestamp);
+      const key = publicationKey("devto", articleId);
+      devtoStore.engagementsByPublication[key] = engagements;
+    }
+  },
   scopeModes: [],
 };

--- a/src/providers/devto/index.ts
+++ b/src/providers/devto/index.ts
@@ -1,0 +1,7 @@
+import type { BackgroundProviderFacet } from "../contract";
+
+export const devtoProvider: BackgroundProviderFacet = {
+  id: "devto",
+  processCapture: () => {},
+  scopeModes: [],
+};

--- a/src/providers/devto/parser.ts
+++ b/src/providers/devto/parser.ts
@@ -1,0 +1,133 @@
+import type {
+  DevToArticleAnalytics,
+  DevToReactionCounts,
+  SocialEngagement,
+} from "../../shared/domain";
+
+type RawReactionCounts = {
+  total?: number;
+  like?: number;
+  readinglist?: number;
+  unicorn?: number;
+  exploding_head?: number;
+  raised_hands?: number;
+  fire?: number;
+  unique_reactors?: number;
+};
+
+type RawAnalytics = {
+  totals?: {
+    comments?: { total?: number };
+    follows?: { total?: number };
+    reactions?: RawReactionCounts;
+    page_views?: {
+      total?: number;
+      average_read_time_in_seconds?: number;
+      total_read_time_in_seconds?: number;
+    };
+  };
+  historical?: Record<string, unknown>;
+  follower_engagement?: {
+    total_followers?: number;
+    engaged_followers?: number;
+    ratio?: number;
+  };
+  referrers?: { domains?: unknown[] };
+};
+
+type RawReaction = {
+  id?: number;
+  user_id?: number;
+  category?: string;
+  created_at?: string;
+};
+
+export type RawReactionsPayload = {
+  current_user?: { id?: number };
+  reactions?: RawReaction[];
+  article_reaction_counts?: { category: string; count: number }[];
+};
+
+function parseReactionCounts(raw: RawReactionCounts | undefined): DevToReactionCounts {
+  const r = raw ?? {};
+  return {
+    total: r.total ?? 0,
+    like: r.like ?? 0,
+    readinglist: r.readinglist ?? 0,
+    unicorn: r.unicorn ?? 0,
+    exploding_head: r.exploding_head ?? 0,
+    raised_hands: r.raised_hands ?? 0,
+    fire: r.fire ?? 0,
+    unique_reactors: r.unique_reactors ?? 0,
+  };
+}
+
+export function parseAnalytics(articleId: string, raw: unknown): DevToArticleAnalytics | null {
+  const r = raw as RawAnalytics;
+  if (!r?.totals) return null;
+  const t = r.totals;
+  const result: DevToArticleAnalytics = {
+    article_id: articleId,
+    totals: {
+      comments: { total: t.comments?.total ?? 0 },
+      follows: { total: t.follows?.total ?? 0 },
+      reactions: parseReactionCounts(t.reactions),
+      page_views: {
+        total: t.page_views?.total ?? 0,
+        average_read_time_in_seconds: t.page_views?.average_read_time_in_seconds ?? 0,
+        total_read_time_in_seconds: t.page_views?.total_read_time_in_seconds ?? 0,
+      },
+    },
+    historical: r.historical ?? {},
+  };
+  if (r.follower_engagement) {
+    result.follower_engagement = {
+      total_followers: r.follower_engagement.total_followers ?? 0,
+      engaged_followers: r.follower_engagement.engaged_followers ?? 0,
+      ratio: r.follower_engagement.ratio ?? 0,
+    };
+  }
+  if (r.referrers) {
+    result.referrers = { domains: r.referrers.domains ?? [] };
+  }
+  return result;
+}
+
+export function parseReactions(
+  articleId: string,
+  raw: unknown,
+  capturedAt: string,
+): SocialEngagement[] {
+  const payload = raw as RawReactionsPayload;
+  if (!Array.isArray(payload?.reactions)) return [];
+
+  const results: SocialEngagement[] = [];
+  for (const r of payload.reactions) {
+    if (!r.id || !r.user_id) continue;
+    const userId = String(r.user_id);
+    results.push({
+      engagement_id: String(r.id),
+      publication_id: articleId,
+      provider: "devto",
+      kind: "like",
+      actor: {
+        provider: "devto",
+        provider_user_id: userId,
+        username: userId,
+        name: userId,
+        avatar_url: "",
+      },
+      engaged_at: r.created_at ?? null,
+      captured_at: capturedAt,
+    });
+  }
+  return results;
+}
+
+export function articleIdFromUrl(url: string): string | null {
+  try {
+    return new URL(url).searchParams.get("article_id");
+  } catch {
+    return null;
+  }
+}

--- a/src/providers/meta.ts
+++ b/src/providers/meta.ts
@@ -8,9 +8,9 @@ export type ProviderMeta = {
   id: SocialProvider;
   name: string;
   color: string;
-  popupPrefix: string; // prefixo dos ids no popup (x, ig, li)
+  popupPrefix: string; // prefixo dos ids no popup (x, ig, li, dt)
   hosts: string[]; // domínios base para casamento em runtime
-  matches: string[]; // padrões chrome para injeção de content script no manifest
+  matches: string[]; // padrões chrome para content_scripts (vazio = Background-only)
   // Hosts adicionais que o provider precisa permissão para CHAMAR (fetch ativo),
   // separados de `matches` para o split do ADR-0003 (Active Fetch). O manifest une os dois
   // em `host_permissions`; ausente = só os `matches` valem como permissão de host.
@@ -25,6 +25,7 @@ export const PROVIDER_METAS: ProviderMeta[] = [
     popupPrefix: "x",
     hosts: ["x.com", "twitter.com"],
     matches: ["https://x.com/*", "https://twitter.com/*"],
+    hostPermissions: ["https://x.com/*", "https://twitter.com/*"],
   },
   {
     id: "instagram",
@@ -33,6 +34,7 @@ export const PROVIDER_METAS: ProviderMeta[] = [
     popupPrefix: "ig",
     hosts: ["instagram.com"],
     matches: ["https://www.instagram.com/*"],
+    hostPermissions: ["https://www.instagram.com/*"],
   },
   {
     id: "linkedin",
@@ -44,6 +46,15 @@ export const PROVIDER_METAS: ProviderMeta[] = [
     // Active Fetch (L3) replica chamadas Voyager para www.linkedin.com — precisa da
     // permissão de host explícita além dos matches de content script.
     hostPermissions: ["https://www.linkedin.com/*"],
+  },
+  {
+    id: "devto",
+    name: "dev.to",
+    color: "#3b49df",
+    popupPrefix: "dt",
+    hosts: ["dev.to"],
+    matches: [],
+    hostPermissions: ["https://dev.to/*"],
   },
 ];
 

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -1,4 +1,4 @@
-export type SocialProvider = "instagram" | "linkedin" | "x";
+export type SocialProvider = "devto" | "instagram" | "linkedin" | "x";
 
 export type SocialActor = {
   avatar_url: string;
@@ -245,6 +245,38 @@ export type LinkedInStore = NormalizedStore & {
   extra: LinkedInExtra;
 };
 
+// DevTo types ---------------------------------------------------------------
+
+export type DevToArticleAnalytics = {
+  article_id: string;
+  totals: {
+    page_views: number;
+    total_read_time_seconds: number;
+    average_read_time_seconds: number;
+    follows: number;
+    comments: number;
+    reactions: {
+      total: number;
+      unique_reactors: number;
+      like: number;
+      readinglist: number;
+      unicorn: number;
+      exploding_head: number;
+      raised_hands: number;
+      fire: number;
+    };
+  };
+  daily: Record<string, unknown>;
+};
+
+export type DevToExtra = {
+  analytics: Record<string, DevToArticleAnalytics>;
+};
+
+export type DevToStore = NormalizedStore & {
+  extra: DevToExtra;
+};
+
 // Main store ----------------------------------------------------------------
 
 // Provenance do Scope (#9): para cada publicação capturada, registra QUAL modo de coleta
@@ -271,6 +303,7 @@ export type BackgroundStore = {
     x: XStore;
     instagram: InstagramStore;
     linkedin: LinkedInStore;
+    devto: DevToStore;
   };
 
   // Provenance por publicação, chaveada por publicationKey(provider, id). Ver ScopeProvenance.

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -247,26 +247,36 @@ export type LinkedInStore = NormalizedStore & {
 
 // DevTo types ---------------------------------------------------------------
 
+export type DevToReactionCounts = {
+  total: number;
+  like: number;
+  readinglist: number;
+  unicorn: number;
+  exploding_head: number;
+  raised_hands: number;
+  fire: number;
+  unique_reactors: number;
+};
+
 export type DevToArticleAnalytics = {
   article_id: string;
   totals: {
-    page_views: number;
-    total_read_time_seconds: number;
-    average_read_time_seconds: number;
-    follows: number;
-    comments: number;
-    reactions: {
+    comments: { total: number };
+    follows: { total: number };
+    reactions: DevToReactionCounts;
+    page_views: {
       total: number;
-      unique_reactors: number;
-      like: number;
-      readinglist: number;
-      unicorn: number;
-      exploding_head: number;
-      raised_hands: number;
-      fire: number;
+      average_read_time_in_seconds: number;
+      total_read_time_in_seconds: number;
     };
   };
-  daily: Record<string, unknown>;
+  historical: Record<string, unknown>;
+  follower_engagement?: {
+    total_followers: number;
+    engaged_followers: number;
+    ratio: number;
+  };
+  referrers?: { domains: unknown[] };
 };
 
 export type DevToExtra = {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -203,6 +203,15 @@ export type ActiveFetchStatusResponse = {
   error?: string; // "uncalibrated" | "session_expired" | "rate_limited" | "error"
 };
 
+export type SetDevtoApiKeyMessage = {
+  action: "SET_DEVTO_API_KEY";
+  apiKey: string | null;
+};
+
+export type GetDevtoApiKeyMessage = {
+  action: "GET_DEVTO_API_KEY";
+};
+
 export type RuntimeMessage =
   | CapturedPayloadMessage
   | GraphqlCapturedMessage
@@ -226,7 +235,9 @@ export type RuntimeMessage =
   | GetRawPayloadsMessage
   | DetectTargetMessage
   | RunActiveFetchMessage
-  | GetActiveFetchStatusMessage;
+  | GetActiveFetchStatusMessage
+  | SetDevtoApiKeyMessage
+  | GetDevtoApiKeyMessage;
 
 export type PageCapturedMessage = {
   endpoint: string;

--- a/test/active-fetch-scheduler.test.ts
+++ b/test/active-fetch-scheduler.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test";
+import { runActiveFetch } from "../src/background/active-fetch-scheduler";
+import type {
+  ActiveFetchRequest,
+  ActiveFetchStrategy,
+  EnumeratedTarget,
+} from "../src/providers/devto/active-fetch";
+
+function makeTarget(id: string): EnumeratedTarget {
+  return { id };
+}
+
+function defaultRequests(target: EnumeratedTarget): ActiveFetchRequest[] {
+  return [
+    {
+      endpoint: "analytics",
+      url: `https://dev.to/api/analytics/historical?article_id=${target.id}`,
+      auth: "api-key",
+      afkSafe: true,
+    },
+    {
+      endpoint: "reactions",
+      url: `https://dev.to/api/reactions?article_id=${target.id}`,
+      auth: "cookie",
+      afkSafe: false,
+    },
+  ];
+}
+
+function stubStrategy(
+  targets: EnumeratedTarget[],
+  requestsFor: (t: EnumeratedTarget) => ActiveFetchRequest[] = defaultRequests,
+): ActiveFetchStrategy {
+  return {
+    kind: "activeFetch",
+    async enumerate({ apiKey }) {
+      return apiKey ? targets : [];
+    },
+    requestsFor,
+  };
+}
+
+type FetchFn = (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function okFetch(body: unknown = {}): FetchFn {
+  return async (_url, _init) => new Response(JSON.stringify(body), { status: 200 });
+}
+
+describe("active-fetch-scheduler", () => {
+  test("a) onDemand: dispara analytics+reactions para cada alvo", async () => {
+    const targets = [makeTarget("1"), makeTarget("2")];
+    const captured: { endpoint: string; payload: unknown }[] = [];
+
+    const status = await runActiveFetch({
+      strategy: stubStrategy(targets),
+      apiKey: "key",
+      mode: "onDemand",
+      fetchFn: okFetch({ ok: true }),
+      onCapture: (endpoint, payload) => captured.push({ endpoint, payload }),
+      delayMs: 0,
+    });
+
+    expect(status.articles).toBe(2);
+    expect(status.collected).toBe(4);
+    expect(status.reactions).toBe(2);
+    expect(captured).toHaveLength(4);
+    expect(captured.filter((c) => c.endpoint === "analytics")).toHaveLength(2);
+    expect(captured.filter((c) => c.endpoint === "reactions")).toHaveLength(2);
+  });
+
+  test("b) afk: só requests afkSafe:true (analytics); reactions ignoradas", async () => {
+    const targets = [makeTarget("1"), makeTarget("2")];
+    const captured: string[] = [];
+
+    const status = await runActiveFetch({
+      strategy: stubStrategy(targets),
+      apiKey: "key",
+      mode: "afk",
+      fetchFn: okFetch(),
+      onCapture: (endpoint) => captured.push(endpoint),
+      delayMs: 0,
+    });
+
+    expect(status.articles).toBe(2);
+    expect(status.collected).toBe(2);
+    expect(status.reactions).toBe(0);
+    expect(captured).toEqual(["analytics", "analytics"]);
+  });
+
+  test("c) throttle: segundo request começa após o primeiro terminar (serial)", async () => {
+    const sequence: string[] = [];
+    let counter = 0;
+
+    const fetchFn: FetchFn = async (_url) => {
+      const id = counter++;
+      sequence.push(`start:${id}`);
+      await Promise.resolve();
+      sequence.push(`end:${id}`);
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    await runActiveFetch({
+      strategy: stubStrategy([makeTarget("1")]),
+      apiKey: "key",
+      mode: "onDemand",
+      fetchFn,
+      onCapture: () => {},
+      delayMs: 0,
+    });
+
+    expect(sequence).toEqual(["start:0", "end:0", "start:1", "end:1"]);
+  });
+
+  test("d) 401 em reactions: sessionNeeded:true, analytics ainda processa", async () => {
+    const fetchFn: FetchFn = async (url) => {
+      const status = String(url).includes("reactions") ? 401 : 200;
+      return new Response(JSON.stringify({}), { status });
+    };
+
+    const captured: string[] = [];
+    const status = await runActiveFetch({
+      strategy: stubStrategy([makeTarget("1")]),
+      apiKey: "key",
+      mode: "onDemand",
+      fetchFn,
+      onCapture: (endpoint) => captured.push(endpoint),
+      delayMs: 0,
+    });
+
+    expect(status.sessionNeeded).toBe(true);
+    expect(status.collected).toBe(1);
+    expect(captured).toEqual(["analytics"]);
+  });
+
+  test("e) apiKey null: apiKeyInvalid:true, collected:0, enumerate não chamado", async () => {
+    let enumerateCalled = false;
+    const strategy: ActiveFetchStrategy = {
+      kind: "activeFetch",
+      async enumerate() {
+        enumerateCalled = true;
+        return [];
+      },
+      requestsFor: () => [],
+    };
+
+    const fetchCalls: string[] = [];
+    const fetchFn: FetchFn = async (url) => {
+      fetchCalls.push(String(url));
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const status = await runActiveFetch({
+      strategy,
+      apiKey: null,
+      mode: "onDemand",
+      fetchFn,
+      onCapture: () => {},
+      delayMs: 0,
+    });
+
+    expect(status.apiKeyInvalid).toBe(true);
+    expect(status.collected).toBe(0);
+    expect(enumerateCalled).toBe(false);
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test("f) erro de rede num request individual não interrompe os demais", async () => {
+    let callIndex = 0;
+    const fetchFn: FetchFn = async (_url) => {
+      const i = callIndex++;
+      if (i === 0) throw new Error("network error");
+      return new Response(JSON.stringify({}), { status: 200 });
+    };
+
+    const captured: string[] = [];
+    const status = await runActiveFetch({
+      strategy: stubStrategy([makeTarget("1")]),
+      apiKey: "key",
+      mode: "onDemand",
+      fetchFn,
+      onCapture: (endpoint) => captured.push(endpoint),
+      delayMs: 0,
+    });
+
+    expect(status.collected).toBe(1);
+    expect(captured).toEqual(["reactions"]);
+  });
+});

--- a/test/active-fetch-scheduler.test.ts
+++ b/test/active-fetch-scheduler.test.ts
@@ -185,4 +185,25 @@ describe("active-fetch-scheduler", () => {
     expect(status.collected).toBe(1);
     expect(captured).toEqual(["reactions"]);
   });
+
+  test("g) 404 em reactions (artigo arquivado): pula silenciosamente, analytics processa", async () => {
+    const fetchFn: FetchFn = async (url) => {
+      const status = String(url).includes("reactions") ? 404 : 200;
+      return new Response(JSON.stringify({}), { status });
+    };
+
+    const captured: string[] = [];
+    const status = await runActiveFetch({
+      strategy: stubStrategy([makeTarget("1")]),
+      apiKey: "key",
+      mode: "onDemand",
+      fetchFn,
+      onCapture: (endpoint) => captured.push(endpoint),
+      delayMs: 0,
+    });
+
+    expect(status.sessionNeeded).toBeUndefined();
+    expect(status.collected).toBe(1);
+    expect(captured).toEqual(["analytics"]);
+  });
 });

--- a/test/providers/devto.test.ts
+++ b/test/providers/devto.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import { createStore } from "../../src/background/controller";
+import { devtoProvider } from "../../src/providers/devto";
+import { articleIdFromUrl, parseAnalytics, parseReactions } from "../../src/providers/devto/parser";
+import { publicationKey } from "../../src/providers/shared/utils";
+import type { DevToStore } from "../../src/shared/domain";
+
+const ARTICLE_ID = "123456";
+const ANALYTICS_URL = `https://dev.to/api/analytics/dashboard?article_id=${ARTICLE_ID}&start=2023-01-01`;
+const REACTIONS_URL = `https://dev.to/reactions?article_id=${ARTICLE_ID}`;
+
+const rawAnalytics = {
+  totals: {
+    comments: { total: 0 },
+    follows: { total: 1 },
+    reactions: {
+      total: 1,
+      like: 0,
+      readinglist: 0,
+      unicorn: 1,
+      exploding_head: 0,
+      raised_hands: 0,
+      fire: 0,
+      unique_reactors: 1,
+    },
+    page_views: { total: 0, average_read_time_in_seconds: 0, total_read_time_in_seconds: 0 },
+  },
+  historical: { "2026-06-03": { reactions: { total: 1 } } },
+  follower_engagement: { total_followers: 1, engaged_followers: 0, ratio: 0 },
+  referrers: { domains: [] },
+};
+
+const rawReactions = {
+  current_user: { id: 894593 },
+  reactions: [
+    {
+      id: 20700191,
+      user_id: 894593,
+      category: "unicorn",
+      created_at: "2026-06-03T14:39:00.092Z",
+    },
+  ],
+  article_reaction_counts: [
+    { category: "like", count: 0 },
+    { category: "unicorn", count: 1 },
+  ],
+};
+
+describe("parseAnalytics", () => {
+  test("mapeia payload completo para DevToArticleAnalytics", () => {
+    const result = parseAnalytics(ARTICLE_ID, rawAnalytics);
+    expect(result).not.toBeNull();
+    expect(result!.article_id).toBe(ARTICLE_ID);
+    expect(result!.totals.follows.total).toBe(1);
+    expect(result!.totals.reactions.total).toBe(1);
+    expect(result!.totals.reactions.unicorn).toBe(1);
+    expect(result!.totals.page_views.total).toBe(0);
+    expect(result!.historical).toEqual({ "2026-06-03": { reactions: { total: 1 } } });
+    expect(result!.follower_engagement?.total_followers).toBe(1);
+  });
+
+  test("retorna null se payload não tem totals", () => {
+    expect(parseAnalytics(ARTICLE_ID, {})).toBeNull();
+    expect(parseAnalytics(ARTICLE_ID, null)).toBeNull();
+  });
+
+  test("preenche zeros para campos ausentes em totals", () => {
+    const result = parseAnalytics(ARTICLE_ID, { totals: {} });
+    expect(result!.totals.page_views.total).toBe(0);
+    expect(result!.totals.reactions.total).toBe(0);
+    expect(result!.totals.follows.total).toBe(0);
+  });
+});
+
+describe("parseReactions", () => {
+  test("mapeia reactions para SocialEngagement[] usando user_id", () => {
+    const engagements = parseReactions(ARTICLE_ID, rawReactions, "2026-06-06T00:00:00Z");
+    expect(engagements).toHaveLength(1);
+
+    const first = engagements[0]!;
+    expect(first.engagement_id).toBe("20700191");
+    expect(first.publication_id).toBe(ARTICLE_ID);
+    expect(first.provider).toBe("devto");
+    expect(first.kind).toBe("like");
+    expect(first.actor.provider_user_id).toBe("894593");
+    expect(first.actor.username).toBe("894593");
+    expect(first.engaged_at).toBe("2026-06-03T14:39:00.092Z");
+    expect(first.captured_at).toBe("2026-06-06T00:00:00Z");
+  });
+
+  test("ignora reactions sem id ou sem user_id", () => {
+    const payload = {
+      reactions: [{ id: 1 }, { user_id: 42 }, { id: 3, user_id: 99 }],
+    };
+    const result = parseReactions(ARTICLE_ID, payload, "");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.engagement_id).toBe("3");
+  });
+
+  test("retorna [] se payload não tem reactions", () => {
+    expect(parseReactions(ARTICLE_ID, {}, "")).toEqual([]);
+    expect(parseReactions(ARTICLE_ID, null, "")).toEqual([]);
+  });
+});
+
+describe("articleIdFromUrl", () => {
+  test("extrai article_id de URL de analytics", () => {
+    expect(articleIdFromUrl(ANALYTICS_URL)).toBe(ARTICLE_ID);
+  });
+
+  test("extrai article_id de URL de reactions", () => {
+    expect(articleIdFromUrl(REACTIONS_URL)).toBe(ARTICLE_ID);
+  });
+
+  test("retorna null para URL inválida", () => {
+    expect(articleIdFromUrl("not-a-url")).toBeNull();
+  });
+});
+
+describe("devtoProvider.processCapture", () => {
+  function makeCapture(endpoint: string, payload: unknown, url: string) {
+    return {
+      action: "CAPTURED_PAYLOAD" as const,
+      provider: "devto" as const,
+      endpoint,
+      payload,
+      url,
+      pageUrl: "https://dev.to",
+      timestamp: "2026-06-06T00:00:00Z",
+    };
+  }
+
+  test("analytics: armazena em extra.analytics", () => {
+    const store = createStore();
+    devtoProvider.processCapture(store, makeCapture("analytics", rawAnalytics, ANALYTICS_URL));
+    const devto = store.platforms.devto as DevToStore;
+    expect(devto.extra.analytics[ARTICLE_ID]).toBeDefined();
+    expect(devto.extra.analytics[ARTICLE_ID]!.totals.reactions.unicorn).toBe(1);
+  });
+
+  test("reactions: armazena em engagementsByPublication", () => {
+    const store = createStore();
+    devtoProvider.processCapture(store, makeCapture("reactions", rawReactions, REACTIONS_URL));
+    const devto = store.platforms.devto as DevToStore;
+    const key = publicationKey("devto", ARTICLE_ID);
+    expect(devto.engagementsByPublication[key]).toHaveLength(1);
+    expect(devto.engagementsByPublication[key]![0]!.actor.provider_user_id).toBe("894593");
+  });
+
+  test("reactions: substitui lista ao re-processar (snapshot completo)", () => {
+    const store = createStore();
+    const single = { reactions: [{ id: 1, user_id: 1 }] };
+    devtoProvider.processCapture(store, makeCapture("reactions", rawReactions, REACTIONS_URL));
+    devtoProvider.processCapture(store, makeCapture("reactions", single, REACTIONS_URL));
+    const key = publicationKey("devto", ARTICLE_ID);
+    expect(store.platforms.devto.engagementsByPublication[key]).toHaveLength(1);
+  });
+
+  test("ignora capture sem url", () => {
+    const store = createStore();
+    devtoProvider.processCapture(store, {
+      action: "CAPTURED_PAYLOAD",
+      provider: "devto",
+      endpoint: "analytics",
+      payload: rawAnalytics,
+      pageUrl: "https://dev.to",
+      timestamp: "2026-06-06T00:00:00Z",
+    });
+    const devto = store.platforms.devto as DevToStore;
+    expect(Object.keys(devto.extra.analytics)).toHaveLength(0);
+  });
+
+  test("ignora endpoint desconhecido", () => {
+    const store = createStore();
+    devtoProvider.processCapture(
+      store,
+      makeCapture("unknown_endpoint", rawAnalytics, ANALYTICS_URL),
+    );
+    const devto = store.platforms.devto as DevToStore;
+    expect(Object.keys(devto.extra.analytics)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Provider dev.to — Active Fetch (analytics por api-key + reactions por sessão)

Resolve #12

---

### Contexto

A extensão He4rt Analytics coleta dados apenas por **Passive Capture** — observado que a página já carrega durante a navegação. Esse modelo não alcança o **dev.to** porque os dados relevantes não aparecem na navegação normal:

- **Analytics dos artigos** (page views, tempo de leitura, follows, reações por tipo/dia) exige o endpoint oficial `GET /api/analytics/historical?article_id=`, autenticado por api-key
- **Quem reagiu** (o Engagement — sinal central para scoring no He4rt Hub) exige a rota `GET /reactions?article_id=`, autenticada por sessão (cookie vivo)

Esta PR introduz o **dev.to como primeiro Background-only Provider** da extensão: coleta 100% por **Active Fetch** originado no service worker, sem injetar content script.

A decisão arquitetural está documentada no ADR-0003.

---

### O que muda

**Para o membro:**
- Cola a api-key na aba Config uma vez
- Clica "Coletar" na aba dev.to estando logado — a extensão lista os artigos, busca analytics e quem reagiu em cada um
- Uma vez por dia, analytics atualiza automaticamente em background (AFK)
- Exporta o JSON v3 com `per_platform.devto` incluso para o He4rt Hub ingerir

**Para o codebase:**
- dev.to é puramente aditivo — export v3 existente permanece byte-idêntico
- Nenhuma camada genérica ganha `if (provider === "devto")`
- Active Fetch é declarativo: o provider declara endpoints, auth e enumeração de alvos; o scheduler é o único orquestrador

---

### Milestones

- [x] Fatia 1 — registra `devto` em `SocialProvider`, `ProviderMeta` e manifest; desacopla `matches` de `hostPermissions`
- [x] Fatia 2 — storage da api-key + UI Config (salvar/remover/mascarar)
- [x] Fatia 3 — seam `ActiveFetchStrategy` + scheduler com fetch injetável e testes
- [x] Fatia 4 — parser dev.to puro + `processCapture` + `DevToStore`
- [ ] Fatia 5 — export v3 + summary + Provenance (golden-master novo, existente byte-idêntico)
- [ ] Fatia 6 — UI da aba dev.to: estados sem key, coletando, deslogado, sucesso

---

### Fora de escopo (v1)

- Multi-tenant (cada membro com sua própria api-key)
- AFK para "quem reagiu" (depende de sessão)
- Modo de Scope `article` avulso
- Cadência configurável do AFK
- Criptografia da api-key no storage (risco registrado no ADR-0003)

---

### Gates por fatia

Ao final de cada fatia: `bun run typecheck` (0 erros), `bun test` (0 fail, snapshots intactos), `bun run build` (compilado em dist/chrome). UI validada no browser manualmente.