### PR TITLE
chore: fix lint errors and add husky + lint-staged

### DIFF
--- a/.github/workflows/validate-extension.yml
+++ b/.github/workflows/validate-extension.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Checar tipos
         run: bun run typecheck
 
-      - name: Validar extensão
-        run: bun run validate
-
       - name: Gerar build carregável no Chrome
         run: bun run build
+
+      - name: Validar extensão
+        run: bun run validate
 
       - name: Gerar pacote da extensão
         run: bun run package

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+bunx lint-staged

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "files": {
-    "includes": ["**", "!dist", "!node_modules", "!*.zip"]
+    "includes": ["**", "!dist", "!node_modules", "!*.zip", "!docs/**/*.html"]
   },
   "formatter": {
     "enabled": true,

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,8 @@
         "@biomejs/biome": "^2.4.15",
         "@types/bun": "^1.3.2",
         "@types/chrome": "^0.1.33",
+        "husky": "^9.1.7",
+        "lint-staged": "^17.0.7",
         "typescript": "^5.9.3",
       },
     },
@@ -43,10 +45,70 @@
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
+    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
+
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "lint-staged": ["lint-staged@17.0.7", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA=="],
+
+    "listr2": ["listr2@10.2.1", "", { "dependencies": { "cli-truncate": "^5.2.0", "eventemitter3": "^5.0.4", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^10.0.0" } }, "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q=="],
+
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+
+    "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
+
+    "string-width": ["string-width@8.2.1", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "wrap-ansi": ["wrap-ansi@10.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "string-width": "^8.2.0", "strip-ansi": "^7.1.2" } }, "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
+    "log-update/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "log-update/wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,12 +11,19 @@
     "package": "bun run scripts/package-extension.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "validate": "bun run check && bun run scripts/validate-extension.ts"
+    "validate": "bun run check && bun run scripts/validate-extension.ts",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{ts,js,json}": "biome check --write --no-errors-on-unmatched",
+    "*.{ts,js,json,css,html}": "biome format --write --no-errors-on-unmatched"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@types/bun": "^1.3.2",
     "@types/chrome": "^0.1.33",
+    "husky": "^9.1.7",
+    "lint-staged": "^17.0.7",
     "typescript": "^5.9.3"
   }
 }

--- a/src/providers/instagram/index.ts
+++ b/src/providers/instagram/index.ts
@@ -336,7 +336,8 @@ function buildCommentTree(comments: SocialComment[]): ExportComment[] {
   }
 
   for (const c of comments) {
-    const node = byId.get(c.comment_id)!;
+    const node = byId.get(c.comment_id);
+    if (!node) continue;
     if (c.parent_comment_id && byId.has(c.parent_comment_id)) {
       byId.get(c.parent_comment_id)?.replies.push(node);
     } else {

--- a/src/providers/linkedin/index.ts
+++ b/src/providers/linkedin/index.ts
@@ -210,9 +210,10 @@ function buildLinkedInCommentWithReactions(
   }
 
   for (const c of items) {
-    const node = byId.get(c.comment_id)!;
+    const node = byId.get(c.comment_id);
+    if (!node) continue;
     if (c.parent_comment_id && byId.has(c.parent_comment_id)) {
-      byId.get(c.parent_comment_id)!.replies.push(node);
+      byId.get(c.parent_comment_id)?.replies.push(node);
     } else {
       roots.push(node);
     }

--- a/test/background.test.ts
+++ b/test/background.test.ts
@@ -170,10 +170,9 @@ describe("background controller", () => {
     };
 
     expect(exported.per_platform.x.engagers.likes_by_tweet["100"]).toHaveLength(2);
-    expect(exported.per_platform.x.engagers.likes_by_tweet["100"]?.map((user) => user.screen_name)).toEqual([
-      "first_fan",
-      "second_fan",
-    ]);
+    expect(
+      exported.per_platform.x.engagers.likes_by_tweet["100"]?.map((user) => user.screen_name),
+    ).toEqual(["first_fan", "second_fan"]);
     expect(exported.per_platform.x.engagers.likes_by_tweet["100"]?.[0]?.followers_count).toBe(1000);
     expect(exported.per_platform.x.engagers.likes_by_tweet["100"]?.[0]?.following).toBe(true);
   });
@@ -242,11 +241,41 @@ describe("background controller", () => {
     const exported = app.sendMessage({ action: "GET_EXPORT" }) as {
       meta: { profiles: Record<string, { username: string }> };
       per_platform: {
-        x: { content: Array<{ tweet_id: string }>; engagers: { replies: unknown[]; likes_by_tweet: Record<string, unknown[]> } };
-        instagram: { content: Array<{ publication_id: string; engagers: { likes: unknown[]; comments: unknown[] } }> };
-        linkedin: { content: Array<{ id: string; engagers: unknown; engagement_metrics: unknown }> };
+        x: {
+          content: Array<{ tweet_id: string }>;
+          engagers: { replies: unknown[]; likes_by_tweet: Record<string, unknown[]> };
+        };
+        instagram: {
+          content: Array<{
+            publication_id: string;
+            engagers: { likes: unknown[]; comments: unknown[] };
+          }>;
+        };
+        linkedin: {
+          content: Array<{ id: string; engagers: unknown; engagement_metrics: unknown }>;
+        };
       };
-      unified: { summary: { all: { total_content: number; total_likes: number; total_comments: number; unique_engagers: number }; by_platform: { x: { total_content: number; total_likes: number; total_retweets: number; total_replies: number; total_quotes: number; total_bookmarks: number; total_views: number } } } };
+      unified: {
+        summary: {
+          all: {
+            total_content: number;
+            total_likes: number;
+            total_comments: number;
+            unique_engagers: number;
+          };
+          by_platform: {
+            x: {
+              total_content: number;
+              total_likes: number;
+              total_retweets: number;
+              total_replies: number;
+              total_quotes: number;
+              total_bookmarks: number;
+              total_views: number;
+            };
+          };
+        };
+      };
     };
 
     expect(Object.keys(endpoints.endpoints).sort()).toEqual(["x:Favoriters", "x:UserTweets"]);
@@ -254,7 +283,7 @@ describe("background controller", () => {
     expect(userTweetPayloads.payloads).toHaveLength(1);
     expect(allRaw.endpoints["x:Favoriters"]?.count).toBe(1);
 
-    expect(exported.meta.profiles.x!.username).toBe("He4rtDevs");
+    expect(exported.meta.profiles.x?.username).toBe("He4rtDevs");
     expect(exported.unified.summary.all.total_content).toBe(5);
     expect(exported.per_platform.x.content).toHaveLength(4);
     expect(exported.per_platform.x.engagers.replies).toHaveLength(1);
@@ -341,15 +370,36 @@ describe("background controller", () => {
       meta: { profiles: Record<string, { username: string }> };
       per_platform: {
         instagram: {
-          content: Array<{ provider: string; shortcode?: string; type: string; publication_id: string; engagers: { likes: unknown[]; comments: Array<{ comment_id: string; replies: unknown[] }> } }>;
+          content: Array<{
+            provider: string;
+            shortcode?: string;
+            type: string;
+            publication_id: string;
+            engagers: {
+              likes: unknown[];
+              comments: Array<{ comment_id: string; replies: unknown[] }>;
+            };
+          }>;
         };
         x: { content: unknown[] };
         linkedin: { content: unknown[] };
       };
       unified: {
         summary: {
-          all: { total_content: number; total_likes: number; total_comments: number; unique_engagers: number };
-          by_platform: { instagram: { total_content: number; total_comments: number; total_likes: number; total_views: number } };
+          all: {
+            total_content: number;
+            total_likes: number;
+            total_comments: number;
+            unique_engagers: number;
+          };
+          by_platform: {
+            instagram: {
+              total_content: number;
+              total_comments: number;
+              total_likes: number;
+              total_views: number;
+            };
+          };
         };
       };
     };
@@ -367,8 +417,8 @@ describe("background controller", () => {
     expect(response.engagementsCount).toBe(4);
 
     expect(exported.meta.profiles.instagram?.username).toBe("he4rtdevs");
-    expect(exported.unified.summary.by_platform.instagram!.total_content).toBe(3);
-    expect(exported.unified.summary.by_platform.instagram!.total_comments).toBe(2);
+    expect(exported.unified.summary.by_platform.instagram?.total_content).toBe(3);
+    expect(exported.unified.summary.by_platform.instagram?.total_comments).toBe(2);
 
     const igPost = exported.per_platform.instagram.content.find((p) => p.shortcode === "ABC123");
     expect(igPost?.engagers.comments).toHaveLength(1);
@@ -403,7 +453,16 @@ describe("background controller", () => {
     );
 
     const exported = app.sendMessage({ action: "GET_EXPORT" }) as {
-      unified: { summary: { all: { total_content: number; total_likes: number; total_comments: number; unique_engagers: number } } };
+      unified: {
+        summary: {
+          all: {
+            total_content: number;
+            total_likes: number;
+            total_comments: number;
+            unique_engagers: number;
+          };
+        };
+      };
     };
 
     expect(exported.unified.summary.all.total_content).toBe(0);
@@ -434,14 +493,22 @@ describe("background controller", () => {
     const exported = app.sendMessage({ action: "GET_EXPORT" }) as {
       per_platform: {
         instagram: {
-          content: Array<{ publication_id: string; shortcode?: string; engagers: { likes: unknown[]; comments: Array<{ comment_id: string; replies: unknown[] }> } }>;
+          content: Array<{
+            publication_id: string;
+            shortcode?: string;
+            engagers: {
+              likes: unknown[];
+              comments: Array<{ comment_id: string; replies: unknown[] }>;
+            };
+          }>;
         };
       };
     };
 
     expect(
-      exported.per_platform.instagram.content.find((publication) => publication.shortcode === "POSTSSR")
-        ?.publication_id,
+      exported.per_platform.instagram.content.find(
+        (publication) => publication.shortcode === "POSTSSR",
+      )?.publication_id,
     ).toBe("394");
     const ssrPost = exported.per_platform.instagram.content.find((p) => p.shortcode === "POSTSSR");
     expect(ssrPost?.engagers.comments).toHaveLength(1);
@@ -749,9 +816,28 @@ describe("background controller", () => {
           }>;
         };
       };
-      unified: { summary: { all: { total_content: number; total_likes: number; total_comments: number; unique_engagers: number }; by_platform: { instagram: { total_content: number; total_comments: number; total_likes: number; total_views: number } } } };
+      unified: {
+        summary: {
+          all: {
+            total_content: number;
+            total_likes: number;
+            total_comments: number;
+            unique_engagers: number;
+          };
+          by_platform: {
+            instagram: {
+              total_content: number;
+              total_comments: number;
+              total_likes: number;
+              total_views: number;
+            };
+          };
+        };
+      };
     };
-    const igPost = exported.per_platform.instagram.content.find((p) => p.shortcode === "DY2ywueFXAj");
+    const igPost = exported.per_platform.instagram.content.find(
+      (p) => p.shortcode === "DY2ywueFXAj",
+    );
     const comments = igPost?.engagers.comments || [];
 
     expect(comments).toHaveLength(1);
@@ -766,7 +852,7 @@ describe("background controller", () => {
       text: "@teamfighttacticsbrasil o top1 hoje tem nome e sobrenome 🤝",
     });
     expect(exported.unified.summary.all.total_comments).toBe(2);
-    expect(exported.unified.summary.by_platform.instagram!.total_comments).toBe(2);
+    expect(exported.unified.summary.by_platform.instagram?.total_comments).toBe(2);
     const raw = app.sendMessage({ action: "GET_RAW_PAYLOADS", provider: "instagram" }) as {
       endpoints: Record<string, { count: number }>;
     };
@@ -799,14 +885,33 @@ describe("background controller", () => {
           content: Array<{
             shortcode?: string;
             publication_id: string;
-            engagers: { likes: unknown[]; comments: Array<{ comment_id: string; text: string; replies: Array<{ comment_id: string; text: string }> }> };
+            engagers: {
+              likes: unknown[];
+              comments: Array<{
+                comment_id: string;
+                text: string;
+                replies: Array<{ comment_id: string; text: string }>;
+              }>;
+            };
           }>;
         };
       };
       unified: {
         summary: {
-          all: { total_content: number; total_likes: number; total_comments: number; unique_engagers: number };
-          by_platform: { instagram: { total_content: number; total_comments: number; total_likes: number; total_views: number } };
+          all: {
+            total_content: number;
+            total_likes: number;
+            total_comments: number;
+            unique_engagers: number;
+          };
+          by_platform: {
+            instagram: {
+              total_content: number;
+              total_comments: number;
+              total_likes: number;
+              total_views: number;
+            };
+          };
         };
       };
     };
@@ -820,7 +925,7 @@ describe("background controller", () => {
     });
     expect(comments?.[0]?.replies).toHaveLength(0);
     expect(exported.unified.summary.all.total_comments).toBe(1);
-    expect(exported.unified.summary.by_platform.instagram!.total_comments).toBe(1);
+    expect(exported.unified.summary.by_platform.instagram?.total_comments).toBe(1);
   });
 
   test("migra comentários DOM visíveis quando o payload real resolve o shortcode do Instagram", () => {
@@ -881,7 +986,16 @@ describe("background controller", () => {
           }>;
         };
       };
-      unified: { summary: { all: { total_content: number; total_likes: number; total_comments: number; unique_engagers: number } } };
+      unified: {
+        summary: {
+          all: {
+            total_content: number;
+            total_likes: number;
+            total_comments: number;
+            unique_engagers: number;
+          };
+        };
+      };
     };
 
     // After SSR: publication created, DOM comments migrated

--- a/test/debug-instagram.test.ts
+++ b/test/debug-instagram.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createStore, handleRuntimeMessage } from "../src/background/controller";
 import { extractInstagramComments } from "../src/providers/instagram/parser";
-import {
-  instagramCommentsPayload,
-  instagramFeedPayload,
-} from "./fixtures/instagram-payloads";
+import { instagramCommentsPayload, instagramFeedPayload } from "./fixtures/instagram-payloads";
 
 describe("debug instagram comments", () => {
   test("trace comment capture flow", () => {
@@ -34,7 +31,10 @@ describe("debug instagram comments", () => {
     });
 
     console.log("After feed, platform pubs:", Object.keys(store.platforms.instagram.publications));
-    console.log("After feed, platform pubIdsByShortcode:", store.platforms.instagram.publicationIdsByShortcode);
+    console.log(
+      "After feed, platform pubIdsByShortcode:",
+      store.platforms.instagram.publicationIdsByShortcode,
+    );
 
     const comments = extractInstagramComments(
       instagramCommentsPayload,
@@ -56,7 +56,10 @@ describe("debug instagram comments", () => {
 
     const pubs = send({ action: "GET_PUBLICATIONS" }) as any;
     console.log("commentsCount:", pubs.commentsCount);
-    console.log("platform comments keys:", Object.keys(store.platforms.instagram.commentsByPublication));
+    console.log(
+      "platform comments keys:",
+      Object.keys(store.platforms.instagram.commentsByPublication),
+    );
 
     // If this is 0, we know the filter is blocking
     expect(pubs.commentsCount).toBe(2);

--- a/test/fixtures/linkedin-payloads.ts
+++ b/test/fixtures/linkedin-payloads.ts
@@ -14,7 +14,9 @@ function vectorImage(seg, width = 400, height = 400) {
 }
 
 function profilePicture(seg) {
-  return { attributes: [{ detailData: { nonEntityProfilePicture: { vectorImage: vectorImage(seg) } } }] };
+  return {
+    attributes: [{ detailData: { nonEntityProfilePicture: { vectorImage: vectorImage(seg) } } }],
+  };
 }
 
 // ---- feedDashOrganizationalPageUpdates ----------------------------------

--- a/test/golden-master.test.ts
+++ b/test/golden-master.test.ts
@@ -77,9 +77,24 @@ describe("golden-master export v3", () => {
   test("X", () => {
     const { send } = harness();
     send({ action: "SET_HANDLE", handle: "He4rtDevs" });
-    capture(send, { provider: "x", endpoint: "UserByScreenName", payload: userByScreenNamePayload, pageUrl: "https://x.com/He4rtDevs" });
-    capture(send, { provider: "x", endpoint: "UserTweets", payload: userTweetsPayload, pageUrl: "https://x.com/He4rtDevs" });
-    capture(send, { provider: "x", endpoint: "Favoriters", payload: favoritersPayload, pageUrl: "https://x.com/He4rtDevs/status/100/likes" });
+    capture(send, {
+      provider: "x",
+      endpoint: "UserByScreenName",
+      payload: userByScreenNamePayload,
+      pageUrl: "https://x.com/He4rtDevs",
+    });
+    capture(send, {
+      provider: "x",
+      endpoint: "UserTweets",
+      payload: userTweetsPayload,
+      pageUrl: "https://x.com/He4rtDevs",
+    });
+    capture(send, {
+      provider: "x",
+      endpoint: "Favoriters",
+      payload: favoritersPayload,
+      pageUrl: "https://x.com/He4rtDevs/status/100/likes",
+    });
 
     expect(exportOf(send)).toMatchSnapshot();
   });
@@ -87,10 +102,30 @@ describe("golden-master export v3", () => {
   test("Instagram", () => {
     const { send } = harness();
     send({ action: "SET_HANDLE", handle: "he4rtdevs" });
-    capture(send, { provider: "instagram", endpoint: "InstagramFeedTimeline", payload: instagramFeedPayload, pageUrl: "https://www.instagram.com/" });
-    capture(send, { provider: "instagram", endpoint: "InstagramMedia", payload: instagramSingleMediaPayload, pageUrl: "https://www.instagram.com/p/CAR789/" });
-    capture(send, { provider: "instagram", endpoint: "InstagramComments", payload: instagramCommentsPayload, pageUrl: "https://www.instagram.com/p/ABC123/" });
-    capture(send, { provider: "instagram", endpoint: "InstagramLikers", payload: instagramLikersPayload, pageUrl: "https://www.instagram.com/p/ABC123/liked_by/" });
+    capture(send, {
+      provider: "instagram",
+      endpoint: "InstagramFeedTimeline",
+      payload: instagramFeedPayload,
+      pageUrl: "https://www.instagram.com/",
+    });
+    capture(send, {
+      provider: "instagram",
+      endpoint: "InstagramMedia",
+      payload: instagramSingleMediaPayload,
+      pageUrl: "https://www.instagram.com/p/CAR789/",
+    });
+    capture(send, {
+      provider: "instagram",
+      endpoint: "InstagramComments",
+      payload: instagramCommentsPayload,
+      pageUrl: "https://www.instagram.com/p/ABC123/",
+    });
+    capture(send, {
+      provider: "instagram",
+      endpoint: "InstagramLikers",
+      payload: instagramLikersPayload,
+      pageUrl: "https://www.instagram.com/p/ABC123/liked_by/",
+    });
 
     expect(exportOf(send)).toMatchSnapshot();
   });
@@ -98,10 +133,33 @@ describe("golden-master export v3", () => {
   test("LinkedIn", () => {
     const { send } = harness();
     send({ action: "SET_HANDLE", handle: "He4rt Developers", provider: "linkedin" });
-    capture(send, { provider: "linkedin", endpoint: "feedDashOrganizationalPageUpdates", payload: linkedinFeedPayload, pageUrl: "https://www.linkedin.com/company/he4rt/" });
-    capture(send, { provider: "linkedin", endpoint: "socialDashReactions", payload: linkedinReactionsPayload, pageUrl: "https://www.linkedin.com/company/he4rt/", url: linkedinReactionsUrl });
-    capture(send, { provider: "linkedin", endpoint: "socialDashComments", payload: linkedinCommentsPayload, pageUrl: "https://www.linkedin.com/company/he4rt/", url: linkedinCommentsUrl });
-    capture(send, { provider: "linkedin", endpoint: "feedDashReshareFeed", payload: linkedinRepostsPayload, pageUrl: "https://www.linkedin.com/company/he4rt/", url: linkedinRepostsUrl });
+    capture(send, {
+      provider: "linkedin",
+      endpoint: "feedDashOrganizationalPageUpdates",
+      payload: linkedinFeedPayload,
+      pageUrl: "https://www.linkedin.com/company/he4rt/",
+    });
+    capture(send, {
+      provider: "linkedin",
+      endpoint: "socialDashReactions",
+      payload: linkedinReactionsPayload,
+      pageUrl: "https://www.linkedin.com/company/he4rt/",
+      url: linkedinReactionsUrl,
+    });
+    capture(send, {
+      provider: "linkedin",
+      endpoint: "socialDashComments",
+      payload: linkedinCommentsPayload,
+      pageUrl: "https://www.linkedin.com/company/he4rt/",
+      url: linkedinCommentsUrl,
+    });
+    capture(send, {
+      provider: "linkedin",
+      endpoint: "feedDashReshareFeed",
+      payload: linkedinRepostsPayload,
+      pageUrl: "https://www.linkedin.com/company/he4rt/",
+      url: linkedinRepostsUrl,
+    });
 
     expect(exportOf(send)).toMatchSnapshot();
   });

--- a/test/scope.test.ts
+++ b/test/scope.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import type { ScopeMode } from "../src/providers/contract";
 import { instagramProvider, scopeModes as instagramScopeModes } from "../src/providers/instagram";
 import { linkedinProvider, scopeModes as linkedinScopeModes } from "../src/providers/linkedin";
-import type { ScopeMode } from "../src/providers/contract";
-import { scopeModes as xScopeModes, xProvider } from "../src/providers/x";
+import { xProvider, scopeModes as xScopeModes } from "../src/providers/x";
 import type { SocialProvider, SocialPublication } from "../src/shared/domain";
 
 // Cobre o seam de Scope (#9): cada provider DECLARA o modo "profile" e a predicate

--- a/test/trace-comments.test.ts
+++ b/test/trace-comments.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { createStore, handleRuntimeMessage } from "../src/background/controller";
-import { extractInstagramComments, extractInstagramPublications } from "../src/providers/instagram/parser";
+import {
+  extractInstagramComments,
+  extractInstagramPublications,
+} from "../src/providers/instagram/parser";
 import { instagramCommentsPayload, instagramFeedPayload } from "./fixtures/instagram-payloads";
 
 describe("trace", () => {
@@ -25,14 +28,23 @@ describe("trace", () => {
     });
 
     const pubs = extractInstagramPublications(instagramFeedPayload);
-    console.log("Feed pubs:", pubs.map((p) => ({ id: p.publication_id, sc: p.shortcode, author: p.author.username })));
+    console.log(
+      "Feed pubs:",
+      pubs.map((p) => ({ id: p.publication_id, sc: p.shortcode, author: p.author.username })),
+    );
 
     const istore = store.platforms.instagram;
     console.log("Platform pubs:", Object.keys(istore.publications));
     console.log("Platform pubIdsBySc:", Object.keys(istore.publicationIdsByShortcode));
 
-    const comments = extractInstagramComments(instagramCommentsPayload, "https://www.instagram.com/p/ABC123/");
-    console.log("Extracted comments:", comments.map((c) => ({ id: c.comment_id, pubId: c.publication_id })));
+    const comments = extractInstagramComments(
+      instagramCommentsPayload,
+      "https://www.instagram.com/p/ABC123/",
+    );
+    console.log(
+      "Extracted comments:",
+      comments.map((c) => ({ id: c.comment_id, pubId: c.publication_id })),
+    );
 
     send({
       action: "CAPTURED_PAYLOAD",


### PR DESCRIPTION
## Summary

- **Biome config**: exclude `docs/**/*.html` from linting (explainer visual, not app code)
- **Non-null assertions**: replace `!` with guard clauses in instagram/linkedin comment tree builders
- **Auto-fixes**: biome formatting, import ordering, and template literals across test suite
- **Husky + lint-staged**: pre-commit hook runs `biome check --write` and `biome format --write` on staged files

This PR makes `bun run check` pass cleanly for the first time — the CI workflow should go green.

## Test plan

- [x] Verify `bun run check` passes (0 errors)
- [x] Verify `bun test` passes (60 tests, 3 snapshots)
- [x] Verify CI check `Validar build, testes e manifest` passes
- [x] Verify pre-commit hook runs on `git commit` (lint-staged output visible)