### PR TITLE
fix(ci): use bun ecosystem in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     commit-message:
       prefix: 'ci'
 
-  - package-ecosystem: 'npm'
+  - package-ecosystem: 'bun'
     directory: '/'
     open-pull-requests-limit: 10
     schedule:


### PR DESCRIPTION
## Summary
- Altera `package-ecosystem` de `npm` para `bun` no Dependabot config
- O ecosystem `npm` não considera o `bun.lock`, gerando PRs com `package.json` atualizado mas lockfile desatualizado (ex: PR #26)
- Com `bun`, o Dependabot vai atualizar ambos os arquivos

## Test plan
- [x] CI passa
- [x] Após merge, Dependabot recria PRs de deps usando `bun.lock`