### PR TITLE
ci: split validation and release workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,31 @@
+name: actionlint
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/*.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Baixar código
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Rodar actionlint
+        uses: docker://rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+        with:
+          args: -color

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,9 +1,10 @@
 name: Auto assign
 
 on:
-  # zizmor: ignore[dangerous-triggers] — não faz checkout, apenas atribui o autor via API
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
-    types: [opened]
+    branches: [main]
+    types: [opened, reopened]
 
 permissions: {}
 
@@ -13,6 +14,7 @@ concurrency:
 
 jobs:
   assign:
+    if: github.repository == 'he4rt/marketing-extension'
     name: Atribuir autor
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -21,6 +23,7 @@ jobs:
 
     steps:
       - name: Atribuir autor da PR
+        if: github.event.pull_request.user.type == 'User'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,28 @@
+name: Auto assign
+
+on:
+  # zizmor: ignore[dangerous-triggers] — não faz checkout, apenas atribui o autor via API
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  assign:
+    name: Atribuir autor
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write # necessário para atribuir o autor à PR
+
+    steps:
+      - name: Atribuir autor da PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.html_url }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: gh pr edit "$PR" --add-assignee "$AUTHOR"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+run-name: BUILD-${{ github.run_number }}
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build, validar e publicar
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write # necessário para criar tags e releases no GitHub
+
+    steps:
+      - name: Baixar código
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Gerar versão CalVer
+        id: version
+        env:
+          TZ: America/Sao_Paulo
+        run: |
+          TIMESTAMP=$(date '+%Y%m%d.%H%M%S')
+          GIT_SHORT=$(git rev-parse --short HEAD)
+          TAG="${TIMESTAMP}.${GIT_SHORT}"
+
+          # Chrome manifest: 1-4 inteiros separados por ponto (0-65535 cada)
+          CHROME_VERSION=$(date '+%Y.%-m%d.%-H%M')
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "chrome_version=${CHROME_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Versão: ${TAG} (manifest: ${CHROME_VERSION})"
+
+      - name: Instalar Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: '.bun-version'
+
+      - name: Cache de node_modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            node-modules-
+
+      - name: Instalar dependências
+        run: bun install --frozen-lockfile
+
+      - name: Gerar build carregável no Chrome
+        env:
+          EXT_VERSION: ${{ steps.version.outputs.chrome_version }}
+          EXT_VERSION_NAME: ${{ steps.version.outputs.tag }}
+        run: bun run build
+
+      - name: Validar extensão
+        run: bun run validate
+
+      - name: Gerar pacote da extensão
+        run: bun run package
+
+      - name: Gerar checksums
+        run: |
+          cd dist/packages
+          sha256sum *.zip > checksums.txt
+
+      - name: Criar release no GitHub
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          gh release create "$RELEASE_TAG" \
+            dist/packages/he4rt-analytics-chrome.zip \
+            dist/packages/checksums.txt \
+            --title "Release $RELEASE_TAG" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.repository == 'he4rt/marketing-extension'
     name: Build, validar e publicar
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Gerar checksums
         run: |
           cd dist/packages
-          sha256sum *.zip > checksums.txt
+          sha256sum ./*.zip > checksums.txt
 
       - name: Criar release no GitHub
         env:

--- a/.github/workflows/validate-extension.yml
+++ b/.github/workflows/validate-extension.yml
@@ -1,10 +1,11 @@
-name: Validar extensão
+name: CI
 
 on:
   pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -15,7 +16,7 @@ concurrency:
 
 jobs:
   validate:
-    name: Validar build, testes e manifest
+    name: Validar tipos, lint e testes
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -44,19 +45,8 @@ jobs:
       - name: Checar tipos
         run: bun run typecheck
 
-      - name: Gerar build carregável no Chrome
-        run: bun run build
+      - name: Checar lint e formatação
+        run: bun run check
 
-      - name: Validar extensão
-        run: bun run validate
-
-      - name: Gerar pacote da extensão
-        run: bun run package
-
-      - name: Upload do pacote
-        if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: he4rt-analytics-chrome-${{ github.run_id }}
-          path: dist/packages/he4rt-analytics-chrome.zip
-          retention-days: 30
+      - name: Rodar testes
+        run: bun test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,24 +311,39 @@ carregando `dist/chrome` no Chrome e navegando. Mudanças nela exigem verificaç
 
 ## CI — GitHub Actions
 
-O workflow **`Validar extensão`** (`.github/workflows/validate-extension.yml`) roda em
-todo PR e push para `main`. O job **`Validar build, testes e manifest`** executa:
+Dois workflows separados:
+
+**`CI`** (`.github/workflows/validate-extension.yml`) — roda em todo PR e push para
+`main`. Job **`Validar tipos, lint e testes`**:
 
 ```
-checkout → setup-bun (.bun-version) → cache node_modules → install →
-typecheck → validate (biome + manifest + testes) → build → package →
-upload-artifact (só em push/main e workflow_dispatch)
+checkout → setup-bun → cache → install → typecheck → biome check → bun test
 ```
 
-Políticas de segurança aplicadas:
+Não faz build — typecheck + lint + testes são suficientes para validação de PR.
+
+**`Release`** (`.github/workflows/release.yml`) — dispatch manual (`workflow_dispatch`).
+Job **`Build, validar e publicar`**:
+
+```
+checkout → CalVer → setup-bun → install → build (EXT_VERSION) →
+validate (manifest + arquivos) → package (.zip) → checksums → gh release create
+```
+
+A versão é CalVer (`YYYYMMDD.HHMMSS.git_short`). O manifest Chrome recebe uma versão
+numérica compatível (`YYYY.MDD.HMM`) via env var `EXT_VERSION`, e o label legível via
+`EXT_VERSION_NAME`. Sem env var, o build usa `1.0.0` (dev local).
+
+**Políticas de segurança** (ambos os workflows):
 
 - **Actions pinadas por SHA** (não por tag) — exigido pelo persona `auditor` do zizmor.
 - **`persist-credentials: false`** no checkout.
-- **Concurrency group** com `cancel-in-progress` para evitar runs duplicados em PRs.
+- **Concurrency group** com `cancel-in-progress` (CI) / sem cancel (Release).
+- **`permissions: {}`** no workflow level, permissões mínimas no job.
 - **Dependabot** (`.github/dependabot.yml`): PRs automáticos semanais para actions e
-  diários para npm, ambos com cooldown de 7 dias e timezone `America/Sao_Paulo`.
+  diários para bun, ambos com cooldown de 7 dias e timezone `America/Sao_Paulo`.
 
-Para validar o workflow localmente: `uvx zizmor . --persona=auditor` (deve retornar 0
+Para validar os workflows localmente: `uvx zizmor . --persona=auditor` (deve retornar 0
 findings).
 
 A versão do Bun usada no CI vem do arquivo `.bun-version` na raiz (mantido em sincronia
@@ -349,7 +364,7 @@ com `.mise.toml`).
 | Mudar modelos de domínio | `shared/domain.ts` |
 | Mudar hosts/abas/manifest | `providers/meta.ts` |
 | Modo de coleta (perfil/hashtag/…) | `providers/<id>/index.ts` (`scopeModes`) + `contract.ts` |
-| Mudar o CI / workflow | `.github/workflows/validate-extension.yml` — actions devem ser pinadas por SHA |
+| Mudar o CI / workflow | `.github/workflows/validate-extension.yml` (CI) e `release.yml` (Release) — actions pinadas por SHA |
 | Atualizar versão do Bun | `.bun-version` (CI) + `.mise.toml` (local) — manter em sincronia |
 | Configurar Dependabot | `.github/dependabot.yml` |
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "package": "bun run scripts/package-extension.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "validate": "bun run check && bun run scripts/validate-extension.ts",
+    "validate": "bun run scripts/validate-extension.ts",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -2,6 +2,15 @@ import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import manifest from "../src/manifest";
 
+const extVersion = process.env.EXT_VERSION;
+const extVersionName = process.env.EXT_VERSION_NAME;
+
+const finalManifest = {
+  ...manifest,
+  ...(extVersion && { version: extVersion }),
+  ...(extVersionName && { version_name: extVersionName }),
+};
+
 const root = path.resolve(import.meta.dir, "..");
 const distDir = path.join(root, "dist", "chrome");
 
@@ -31,7 +40,7 @@ async function copyFile(from: string, to: string) {
 await rm(distDir, { force: true, recursive: true });
 await mkdir(path.join(distDir, "icons"), { recursive: true });
 
-await writeFile(path.join(distDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+await writeFile(path.join(distDir, "manifest.json"), `${JSON.stringify(finalManifest, null, 2)}\n`);
 
 await buildEntry("src/background/index.ts", "background.js", "esm");
 await buildEntry("src/content/index.ts", "content.js", "iife");

--- a/scripts/package-extension.ts
+++ b/scripts/package-extension.ts
@@ -1,4 +1,5 @@
-import { mkdir } from "node:fs/promises";
+import { constants } from "node:fs";
+import { access, mkdir } from "node:fs/promises";
 import path from "node:path";
 
 const root = path.resolve(import.meta.dir, "..");
@@ -6,7 +7,12 @@ const distDir = path.join(root, "dist", "chrome");
 const packageDir = path.join(root, "dist", "packages");
 const zipPath = path.join(packageDir, "he4rt-analytics-chrome.zip");
 
-await Bun.$`bun run build`;
+try {
+  await access(path.join(distDir, "manifest.json"), constants.R_OK);
+} catch {
+  throw new Error("dist/chrome/ não encontrado. Execute 'bun run build' antes de empacotar.");
+}
+
 await mkdir(packageDir, { recursive: true });
 await Bun.$`rm -f ${zipPath}`;
 await Bun.$`cd ${distDir} && zip -qr ${zipPath} .`;

--- a/scripts/validate-extension.ts
+++ b/scripts/validate-extension.ts
@@ -127,16 +127,10 @@ async function validateSyntax() {
   ok("scripts compilados fazem parse");
 }
 
-async function runTests() {
-  await run("bun", ["test"]);
-  ok("testes passam");
-}
-
 try {
   await validateRequiredFiles();
   await validateManifest();
   await validateSyntax();
-  await runTests();
   console.log("Validação da extensão concluída.");
 } catch (error) {
   console.error(`Validação falhou: ${error instanceof Error ? error.message : String(error)}`);


### PR DESCRIPTION
## Summary
- Separa o workflow único em **CI** (typecheck + lint + testes) e **Release** (build + validate + package + GitHub Release)
- CI não faz build — feedback mais rápido em PRs
- Release via `workflow_dispatch` manual com versionamento **CalVer** (`YYYYMMDD.HHMMSS.git_short`)
- Adiciona **actionlint** para validar syntax dos workflows em PRs
- Adiciona **auto-assign** para atribuir o autor à PR automaticamente
- Refatora scripts: `validate-extension.ts` sem testes, `build.ts` com injeção de versão, `package-extension.ts` sem build embutido

## Detalhes

### CI (`validate-extension.yml`)
- Trigger: `pull_request` (opened/reopened/synchronize/ready_for_review) + push main
- Steps: typecheck → biome check → bun test
- Sem build, sem artifact

### Release (`release.yml`)
- Trigger: `workflow_dispatch`
- CalVer: manifest Chrome recebe `YYYY.MDD.HMM`, label recebe tag completa
- Steps: build (com versão) → validate manifest → package → checksums → gh release create
- Guard: `github.repository` para prevenir dispatch em forks

### actionlint (`actionlint.yml`)
- Roda apenas quando `*.yml` em `.github/workflows/` muda
- Docker image pinada por digest

### auto-assign (`auto-assign.yml`)
- `pull_request_target` com remediações: branch filter, repo check, bot guard
- zizmor ignore justificado (sem checkout, apenas API call)

## Test plan
- [ ] CI passa (typecheck + check + test sem build)
- [ ] `bun run build && bun run validate && bun run package` funciona local
- [ ] `EXT_VERSION=2026.604.1830 EXT_VERSION_NAME=20260604.183000.abc bun run build` injeta versão no manifest
- [ ] `uvx zizmor . --persona=auditor` retorna 0 findings