### PR TITLE
ci: exclude bots from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,10 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]
+      - github-actions[bot]
+      - pre-commit-ci[bot]
+  categories:
+    - title: Mudanças
+      labels:
+        - '*'


### PR DESCRIPTION
## Summary
- Adiciona `.github/release.yml` para configurar release notes automáticas
- Exclui commits de bots do changelog: `dependabot[bot]`, `github-actions[bot]`, `pre-commit-ci[bot]`

## Test plan
- [ ] Verificar na próxima release que PRs do Dependabot não aparecem no changelog