### PR TITLE
feat(devto): parser + processCapture + DevToStore (Fatia 4) — #20

### DIFF
--- a/src/background/active-fetch-scheduler.ts
+++ b/src/background/active-fetch-scheduler.ts
@@ -9,7 +9,7 @@ export async function runActiveFetch(opts: {
   apiKey: string | null;
   mode: "onDemand" | "afk";
   fetchFn?: FetchFn;
-  onCapture: (endpoint: string, payload: unknown) => void;
+  onCapture: (endpoint: string, payload: unknown, url: string) => void;
   delayMs?: number;
 }): Promise<ActiveFetchStatus> {
   const { strategy, apiKey, mode, fetchFn = fetch as FetchFn, onCapture, delayMs = 300 } = opts;
@@ -36,16 +36,15 @@ export async function runActiveFetch(opts: {
     if (i > 0) await sleep(delayMs);
     try {
       const fetchOpts: RequestInit =
-        req.auth === "api-key"
-          ? { headers: { "api-key": apiKey } }
-          : { credentials: "include" };
+        req.auth === "api-key" ? { headers: { "api-key": apiKey } } : { credentials: "include" };
       const res = await fetchFn(req.url, fetchOpts);
       if (res.status === 401 || res.status === 403) {
         sessionNeeded = true;
         continue;
       }
+      if (!res.ok) continue;
       const payload = await res.json();
-      onCapture(req.endpoint, payload);
+      onCapture(req.endpoint, payload, req.url);
       collected++;
       if (req.endpoint === "reactions") reactionCount++;
     } catch {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,6 +1,6 @@
+import { getActiveFetchStrategy } from "../providers/active-fetch-registry";
 import type { BackgroundStore, EndpointStore, SocialProvider } from "../shared/domain";
 import type { RuntimeMessage } from "../shared/messages";
-import { getActiveFetchStrategy } from "../providers/active-fetch-registry";
 import { runActiveFetch } from "./active-fetch-scheduler";
 import { createStore, handleRuntimeMessage } from "./controller";
 
@@ -164,7 +164,7 @@ chrome.runtime.onMessage.addListener((request: RuntimeMessage, _sender, sendResp
     return true;
   }
 
-  if (request.action === "RUN_ACTIVE_FETCH") {
+  if (request.action === "RUN_ACTIVE_FETCH" && request.provider === "devto") {
     const provider = request.provider;
     chrome.storage.local.get("devtoApiKey").then(async (result) => {
       const apiKey = (result.devtoApiKey as string | undefined) ?? null;

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -23,23 +23,26 @@ if (chrome.alarms) {
     if (alarm.name !== "devto-afk") return;
     const strategy = getActiveFetchStrategy("devto");
     if (!strategy) return;
+    await hydration;
     const result = await chrome.storage.local.get("devtoApiKey");
     const apiKey = (result.devtoApiKey as string | undefined) ?? null;
     await runActiveFetch({
       strategy,
       apiKey,
       mode: "afk",
-      onCapture: (endpoint, payload) => {
+      onCapture: (endpoint, payload, url) => {
         handleRuntimeMessage(store, {
           action: "CAPTURED_PAYLOAD",
           provider: "devto",
           endpoint,
           payload,
+          url,
           pageUrl: "https://dev.to",
           timestamp: new Date().toISOString(),
         });
       },
     });
+    persistSession();
   });
 }
 
@@ -74,6 +77,7 @@ async function hydrate() {
     if (s.x) Object.assign(store.platforms.x, s.x);
     if (s.instagram) Object.assign(store.platforms.instagram, s.instagram);
     if (s.linkedin) Object.assign(store.platforms.linkedin, s.linkedin);
+    if (s.devto) Object.assign(store.platforms.devto, s.devto);
   }
 
   store.lastUpdated = new Date().toISOString();
@@ -92,6 +96,7 @@ function persistSession(): Promise<void> {
     x: store.platforms.x,
     instagram: store.platforms.instagram,
     linkedin: store.platforms.linkedin,
+    devto: store.platforms.devto,
   };
   persistQueue = persistQueue
     .then(() => chrome.storage.session.set({ [SESSION_KEY]: snapshot }))
@@ -166,31 +171,34 @@ chrome.runtime.onMessage.addListener((request: RuntimeMessage, _sender, sendResp
 
   if (request.action === "RUN_ACTIVE_FETCH" && request.provider === "devto") {
     const provider = request.provider;
-    chrome.storage.local.get("devtoApiKey").then(async (result) => {
-      const apiKey = (result.devtoApiKey as string | undefined) ?? null;
-      const strategy = getActiveFetchStrategy(provider);
-      if (!strategy) {
-        sendResponse({ collected: 0, articles: 0, reactions: 0 });
-        return;
-      }
-      const status = await runActiveFetch({
-        strategy,
-        apiKey,
-        mode: "onDemand",
-        onCapture: (endpoint, payload) => {
-          handleRuntimeMessage(store, {
-            action: "CAPTURED_PAYLOAD",
-            provider,
-            endpoint,
-            payload,
-            pageUrl: "https://dev.to",
-            timestamp: new Date().toISOString(),
-          });
-        },
+    hydration
+      .then(() => chrome.storage.local.get("devtoApiKey"))
+      .then(async (result) => {
+        const apiKey = (result.devtoApiKey as string | undefined) ?? null;
+        const strategy = getActiveFetchStrategy(provider);
+        if (!strategy) {
+          sendResponse({ collected: 0, articles: 0, reactions: 0 });
+          return;
+        }
+        const status = await runActiveFetch({
+          strategy,
+          apiKey,
+          mode: "onDemand",
+          onCapture: (endpoint, payload, url) => {
+            handleRuntimeMessage(store, {
+              action: "CAPTURED_PAYLOAD",
+              provider,
+              endpoint,
+              payload,
+              url,
+              pageUrl: "https://dev.to",
+              timestamp: new Date().toISOString(),
+            });
+          },
+        });
+        persistSession();
+        sendResponse(status);
       });
-      persistSession();
-      sendResponse(status);
-    });
     return true;
   }
 

--- a/src/providers/devto/active-fetch.ts
+++ b/src/providers/devto/active-fetch.ts
@@ -32,19 +32,19 @@ export const devtoActiveFetchStrategy: ActiveFetchStrategy = {
     });
     if (!res.ok) return [];
     const articles = (await res.json()) as Array<{ id: number }>;
-    return articles.map((a) => ({ id: String(a.id), meta: a }));
+    return articles.map((a) => ({ id: String(a.id) }));
   },
   requestsFor(target) {
     return [
       {
         endpoint: "analytics",
-        url: `https://dev.to/api/analytics/historical?article_id=${target.id}`,
+        url: `https://dev.to/api/analytics/dashboard?article_id=${target.id}`,
         auth: "api-key",
         afkSafe: true,
       },
       {
         endpoint: "reactions",
-        url: `https://dev.to/api/reactions?article_id=${target.id}`,
+        url: `https://dev.to/reactions?article_id=${target.id}`,
         auth: "cookie",
         afkSafe: false,
       },

--- a/src/providers/devto/index.ts
+++ b/src/providers/devto/index.ts
@@ -1,7 +1,28 @@
+import type { DevToStore } from "../../shared/domain";
 import type { BackgroundProviderFacet } from "../contract";
+import { publicationKey } from "../shared/utils";
+import { articleIdFromUrl, parseAnalytics, parseReactions } from "./parser";
 
 export const devtoProvider: BackgroundProviderFacet = {
   id: "devto",
-  processCapture: () => {},
+  processCapture(store, capture) {
+    if (capture.provider !== "devto") return;
+
+    const articleId = capture.url ? articleIdFromUrl(capture.url) : null;
+    if (!articleId) return;
+
+    const devtoStore = store.platforms.devto as DevToStore;
+
+    if (capture.endpoint === "analytics") {
+      const analytics = parseAnalytics(articleId, capture.payload);
+      if (analytics) {
+        devtoStore.extra.analytics[articleId] = analytics;
+      }
+    } else if (capture.endpoint === "reactions") {
+      const engagements = parseReactions(articleId, capture.payload, capture.timestamp);
+      const key = publicationKey("devto", articleId);
+      devtoStore.engagementsByPublication[key] = engagements;
+    }
+  },
   scopeModes: [],
 };

--- a/src/providers/devto/parser.ts
+++ b/src/providers/devto/parser.ts
@@ -1,0 +1,133 @@
+import type {
+  DevToArticleAnalytics,
+  DevToReactionCounts,
+  SocialEngagement,
+} from "../../shared/domain";
+
+type RawReactionCounts = {
+  total?: number;
+  like?: number;
+  readinglist?: number;
+  unicorn?: number;
+  exploding_head?: number;
+  raised_hands?: number;
+  fire?: number;
+  unique_reactors?: number;
+};
+
+type RawAnalytics = {
+  totals?: {
+    comments?: { total?: number };
+    follows?: { total?: number };
+    reactions?: RawReactionCounts;
+    page_views?: {
+      total?: number;
+      average_read_time_in_seconds?: number;
+      total_read_time_in_seconds?: number;
+    };
+  };
+  historical?: Record<string, unknown>;
+  follower_engagement?: {
+    total_followers?: number;
+    engaged_followers?: number;
+    ratio?: number;
+  };
+  referrers?: { domains?: unknown[] };
+};
+
+type RawReaction = {
+  id?: number;
+  user_id?: number;
+  category?: string;
+  created_at?: string;
+};
+
+export type RawReactionsPayload = {
+  current_user?: { id?: number };
+  reactions?: RawReaction[];
+  article_reaction_counts?: { category: string; count: number }[];
+};
+
+function parseReactionCounts(raw: RawReactionCounts | undefined): DevToReactionCounts {
+  const r = raw ?? {};
+  return {
+    total: r.total ?? 0,
+    like: r.like ?? 0,
+    readinglist: r.readinglist ?? 0,
+    unicorn: r.unicorn ?? 0,
+    exploding_head: r.exploding_head ?? 0,
+    raised_hands: r.raised_hands ?? 0,
+    fire: r.fire ?? 0,
+    unique_reactors: r.unique_reactors ?? 0,
+  };
+}
+
+export function parseAnalytics(articleId: string, raw: unknown): DevToArticleAnalytics | null {
+  const r = raw as RawAnalytics;
+  if (!r?.totals) return null;
+  const t = r.totals;
+  const result: DevToArticleAnalytics = {
+    article_id: articleId,
+    totals: {
+      comments: { total: t.comments?.total ?? 0 },
+      follows: { total: t.follows?.total ?? 0 },
+      reactions: parseReactionCounts(t.reactions),
+      page_views: {
+        total: t.page_views?.total ?? 0,
+        average_read_time_in_seconds: t.page_views?.average_read_time_in_seconds ?? 0,
+        total_read_time_in_seconds: t.page_views?.total_read_time_in_seconds ?? 0,
+      },
+    },
+    historical: r.historical ?? {},
+  };
+  if (r.follower_engagement) {
+    result.follower_engagement = {
+      total_followers: r.follower_engagement.total_followers ?? 0,
+      engaged_followers: r.follower_engagement.engaged_followers ?? 0,
+      ratio: r.follower_engagement.ratio ?? 0,
+    };
+  }
+  if (r.referrers) {
+    result.referrers = { domains: r.referrers.domains ?? [] };
+  }
+  return result;
+}
+
+export function parseReactions(
+  articleId: string,
+  raw: unknown,
+  capturedAt: string,
+): SocialEngagement[] {
+  const payload = raw as RawReactionsPayload;
+  if (!Array.isArray(payload?.reactions)) return [];
+
+  const results: SocialEngagement[] = [];
+  for (const r of payload.reactions) {
+    if (!r.id || !r.user_id) continue;
+    const userId = String(r.user_id);
+    results.push({
+      engagement_id: String(r.id),
+      publication_id: articleId,
+      provider: "devto",
+      kind: "like",
+      actor: {
+        provider: "devto",
+        provider_user_id: userId,
+        username: userId,
+        name: userId,
+        avatar_url: "",
+      },
+      engaged_at: r.created_at ?? null,
+      captured_at: capturedAt,
+    });
+  }
+  return results;
+}
+
+export function articleIdFromUrl(url: string): string | null {
+  try {
+    return new URL(url).searchParams.get("article_id");
+  } catch {
+    return null;
+  }
+}

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -247,26 +247,36 @@ export type LinkedInStore = NormalizedStore & {
 
 // DevTo types ---------------------------------------------------------------
 
+export type DevToReactionCounts = {
+  total: number;
+  like: number;
+  readinglist: number;
+  unicorn: number;
+  exploding_head: number;
+  raised_hands: number;
+  fire: number;
+  unique_reactors: number;
+};
+
 export type DevToArticleAnalytics = {
   article_id: string;
   totals: {
-    page_views: number;
-    total_read_time_seconds: number;
-    average_read_time_seconds: number;
-    follows: number;
-    comments: number;
-    reactions: {
+    comments: { total: number };
+    follows: { total: number };
+    reactions: DevToReactionCounts;
+    page_views: {
       total: number;
-      unique_reactors: number;
-      like: number;
-      readinglist: number;
-      unicorn: number;
-      exploding_head: number;
-      raised_hands: number;
-      fire: number;
+      average_read_time_in_seconds: number;
+      total_read_time_in_seconds: number;
     };
   };
-  daily: Record<string, unknown>;
+  historical: Record<string, unknown>;
+  follower_engagement?: {
+    total_followers: number;
+    engaged_followers: number;
+    ratio: number;
+  };
+  referrers?: { domains: unknown[] };
 };
 
 export type DevToExtra = {

--- a/test/active-fetch-scheduler.test.ts
+++ b/test/active-fetch-scheduler.test.ts
@@ -185,4 +185,25 @@ describe("active-fetch-scheduler", () => {
     expect(status.collected).toBe(1);
     expect(captured).toEqual(["reactions"]);
   });
+
+  test("g) 404 em reactions (artigo arquivado): pula silenciosamente, analytics processa", async () => {
+    const fetchFn: FetchFn = async (url) => {
+      const status = String(url).includes("reactions") ? 404 : 200;
+      return new Response(JSON.stringify({}), { status });
+    };
+
+    const captured: string[] = [];
+    const status = await runActiveFetch({
+      strategy: stubStrategy([makeTarget("1")]),
+      apiKey: "key",
+      mode: "onDemand",
+      fetchFn,
+      onCapture: (endpoint) => captured.push(endpoint),
+      delayMs: 0,
+    });
+
+    expect(status.sessionNeeded).toBeUndefined();
+    expect(status.collected).toBe(1);
+    expect(captured).toEqual(["analytics"]);
+  });
 });

--- a/test/providers/devto.test.ts
+++ b/test/providers/devto.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import { createStore } from "../../src/background/controller";
+import { devtoProvider } from "../../src/providers/devto";
+import { articleIdFromUrl, parseAnalytics, parseReactions } from "../../src/providers/devto/parser";
+import { publicationKey } from "../../src/providers/shared/utils";
+import type { DevToStore } from "../../src/shared/domain";
+
+const ARTICLE_ID = "123456";
+const ANALYTICS_URL = `https://dev.to/api/analytics/dashboard?article_id=${ARTICLE_ID}&start=2023-01-01`;
+const REACTIONS_URL = `https://dev.to/reactions?article_id=${ARTICLE_ID}`;
+
+const rawAnalytics = {
+  totals: {
+    comments: { total: 0 },
+    follows: { total: 1 },
+    reactions: {
+      total: 1,
+      like: 0,
+      readinglist: 0,
+      unicorn: 1,
+      exploding_head: 0,
+      raised_hands: 0,
+      fire: 0,
+      unique_reactors: 1,
+    },
+    page_views: { total: 0, average_read_time_in_seconds: 0, total_read_time_in_seconds: 0 },
+  },
+  historical: { "2026-06-03": { reactions: { total: 1 } } },
+  follower_engagement: { total_followers: 1, engaged_followers: 0, ratio: 0 },
+  referrers: { domains: [] },
+};
+
+const rawReactions = {
+  current_user: { id: 894593 },
+  reactions: [
+    {
+      id: 20700191,
+      user_id: 894593,
+      category: "unicorn",
+      created_at: "2026-06-03T14:39:00.092Z",
+    },
+  ],
+  article_reaction_counts: [
+    { category: "like", count: 0 },
+    { category: "unicorn", count: 1 },
+  ],
+};
+
+describe("parseAnalytics", () => {
+  test("mapeia payload completo para DevToArticleAnalytics", () => {
+    const result = parseAnalytics(ARTICLE_ID, rawAnalytics);
+    expect(result).not.toBeNull();
+    expect(result!.article_id).toBe(ARTICLE_ID);
+    expect(result!.totals.follows.total).toBe(1);
+    expect(result!.totals.reactions.total).toBe(1);
+    expect(result!.totals.reactions.unicorn).toBe(1);
+    expect(result!.totals.page_views.total).toBe(0);
+    expect(result!.historical).toEqual({ "2026-06-03": { reactions: { total: 1 } } });
+    expect(result!.follower_engagement?.total_followers).toBe(1);
+  });
+
+  test("retorna null se payload não tem totals", () => {
+    expect(parseAnalytics(ARTICLE_ID, {})).toBeNull();
+    expect(parseAnalytics(ARTICLE_ID, null)).toBeNull();
+  });
+
+  test("preenche zeros para campos ausentes em totals", () => {
+    const result = parseAnalytics(ARTICLE_ID, { totals: {} });
+    expect(result!.totals.page_views.total).toBe(0);
+    expect(result!.totals.reactions.total).toBe(0);
+    expect(result!.totals.follows.total).toBe(0);
+  });
+});
+
+describe("parseReactions", () => {
+  test("mapeia reactions para SocialEngagement[] usando user_id", () => {
+    const engagements = parseReactions(ARTICLE_ID, rawReactions, "2026-06-06T00:00:00Z");
+    expect(engagements).toHaveLength(1);
+
+    const first = engagements[0]!;
+    expect(first.engagement_id).toBe("20700191");
+    expect(first.publication_id).toBe(ARTICLE_ID);
+    expect(first.provider).toBe("devto");
+    expect(first.kind).toBe("like");
+    expect(first.actor.provider_user_id).toBe("894593");
+    expect(first.actor.username).toBe("894593");
+    expect(first.engaged_at).toBe("2026-06-03T14:39:00.092Z");
+    expect(first.captured_at).toBe("2026-06-06T00:00:00Z");
+  });
+
+  test("ignora reactions sem id ou sem user_id", () => {
+    const payload = {
+      reactions: [{ id: 1 }, { user_id: 42 }, { id: 3, user_id: 99 }],
+    };
+    const result = parseReactions(ARTICLE_ID, payload, "");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.engagement_id).toBe("3");
+  });
+
+  test("retorna [] se payload não tem reactions", () => {
+    expect(parseReactions(ARTICLE_ID, {}, "")).toEqual([]);
+    expect(parseReactions(ARTICLE_ID, null, "")).toEqual([]);
+  });
+});
+
+describe("articleIdFromUrl", () => {
+  test("extrai article_id de URL de analytics", () => {
+    expect(articleIdFromUrl(ANALYTICS_URL)).toBe(ARTICLE_ID);
+  });
+
+  test("extrai article_id de URL de reactions", () => {
+    expect(articleIdFromUrl(REACTIONS_URL)).toBe(ARTICLE_ID);
+  });
+
+  test("retorna null para URL inválida", () => {
+    expect(articleIdFromUrl("not-a-url")).toBeNull();
+  });
+});
+
+describe("devtoProvider.processCapture", () => {
+  function makeCapture(endpoint: string, payload: unknown, url: string) {
+    return {
+      action: "CAPTURED_PAYLOAD" as const,
+      provider: "devto" as const,
+      endpoint,
+      payload,
+      url,
+      pageUrl: "https://dev.to",
+      timestamp: "2026-06-06T00:00:00Z",
+    };
+  }
+
+  test("analytics: armazena em extra.analytics", () => {
+    const store = createStore();
+    devtoProvider.processCapture(store, makeCapture("analytics", rawAnalytics, ANALYTICS_URL));
+    const devto = store.platforms.devto as DevToStore;
+    expect(devto.extra.analytics[ARTICLE_ID]).toBeDefined();
+    expect(devto.extra.analytics[ARTICLE_ID]!.totals.reactions.unicorn).toBe(1);
+  });
+
+  test("reactions: armazena em engagementsByPublication", () => {
+    const store = createStore();
+    devtoProvider.processCapture(store, makeCapture("reactions", rawReactions, REACTIONS_URL));
+    const devto = store.platforms.devto as DevToStore;
+    const key = publicationKey("devto", ARTICLE_ID);
+    expect(devto.engagementsByPublication[key]).toHaveLength(1);
+    expect(devto.engagementsByPublication[key]![0]!.actor.provider_user_id).toBe("894593");
+  });
+
+  test("reactions: substitui lista ao re-processar (snapshot completo)", () => {
+    const store = createStore();
+    const single = { reactions: [{ id: 1, user_id: 1 }] };
+    devtoProvider.processCapture(store, makeCapture("reactions", rawReactions, REACTIONS_URL));
+    devtoProvider.processCapture(store, makeCapture("reactions", single, REACTIONS_URL));
+    const key = publicationKey("devto", ARTICLE_ID);
+    expect(store.platforms.devto.engagementsByPublication[key]).toHaveLength(1);
+  });
+
+  test("ignora capture sem url", () => {
+    const store = createStore();
+    devtoProvider.processCapture(store, {
+      action: "CAPTURED_PAYLOAD",
+      provider: "devto",
+      endpoint: "analytics",
+      payload: rawAnalytics,
+      pageUrl: "https://dev.to",
+      timestamp: "2026-06-06T00:00:00Z",
+    });
+    const devto = store.platforms.devto as DevToStore;
+    expect(Object.keys(devto.extra.analytics)).toHaveLength(0);
+  });
+
+  test("ignora endpoint desconhecido", () => {
+    const store = createStore();
+    devtoProvider.processCapture(
+      store,
+      makeCapture("unknown_endpoint", rawAnalytics, ANALYTICS_URL),
+    );
+    const devto = store.platforms.devto as DevToStore;
+    expect(Object.keys(devto.extra.analytics)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Motivação

Fatia 4 do provider dev.to ([ADR-0003](docs/adr/0003-active-fetch-provider-devto.md)): ligar o `Active Fetch` ao store — o scheduler já existia (Fatia 3), mas `processCapture` era stub e os dados nunca chegavam ao `BackgroundStore`.

Inclui também três fixes descobertos durante validação manual:

- Scheduler não passava a URL para `onCapture` (sem URL → sem `article_id` → parse impossível).
- Endpoints corrigidos após teste real: `analytics/historical` → `analytics/dashboard`, `/api/reactions` → `/reactions`.
- Background não integrava devto na hidratação, `persistSession` e handler AFK.

## O que mudou

| Área | Mudança |
|---|---|
| `providers/devto/parser.ts` *(novo)* | `parseAnalytics` (mapeia `totals`/`historical`/`follower_engagement`/`r`parseReactions` (→ `SocialEngagement[]`), `art
| `providers/devto/index.ts` | `processCapture` completo: analytics → `extra.analytics[articleId]`, reactions → `engagementsByPublication[key]` (replace, não a
| `shared/domain.ts` | `DevToReactionCounts` extraído; `DevToArticleAnalytics` reescrito para refletir shape real do
`dashboard` |
| `providers/devto/active-fetch.ts` | URLs corrigidas; `published_at`/`start` removidos (dashboard não precisa) |
| `background/active-fetch-scheduler.ts` | `onCcomo terceiro parâmetro; respostas não-2xxpuladas (além de 401/403) |
| `background/index.ts` | devto adicionado a `pandler AFK; `RUN_ACTIVE_FETCH` aguarda`hydration` antes de buscar a api-key |
| `test/providers/devto.test.ts` *(novo)* | 14 ions, articleIdFromUrl e processCapture(incluindo replace-on-reprocess e url ausente) |

## Limitação consciente

`reactions` da API dev.to retorna **apenas as reações do usuário autenticado** (não todos os reatores). O `SocialEngagement` usa `user_id` numérico como actor — sem nome/avDocumentado; comportamento correto dado o que a API expõe.

## Gates

bun test        184 pass / 0 fail · 4 snapshots (golden-master byte-idêntico)
bun run typecheck   0 erros
bun run build       dist/chrome OK

## Validação manual (HITL)

1. **onDemand** — `RUN_ACTIVE_FETCH` no console do SW → `{collected: 4, articles: 2, reactions: 2}`, store populado
corretamente em `session.he4rt_platforms.devto`
2. **AFK** — alarm disparado manualmente, timestamp `captured_at` do analytics atualizado. ✓
3. **Sem api-key** — coberto por testes unitárirue`). ✓
4. **Sessão expirada** — analytics (api-key only) funciona; reactions retorna `sessionNeeded: true`. ✓

## Deferido (Fatias 5 e 6)

- [ ] Export v3 + `buildPlatformData` + `computeSummary` + golden-master novo (Fatia 5)
- [ ] Aba dev.to no side panel (Fatia 6)