### PR TITLE
ci(auto-assign): use shared action pinned by SHA

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -15,17 +15,10 @@ concurrency:
 jobs:
   assign:
     if: github.repository == 'he4rt/marketing-extension'
-    name: Atribuir autor
+    name: Author
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      pull-requests: write # necessário para atribuir o autor à PR
-
+      pull-requests: write # necessário para atribuir o autor ao PR
     steps:
-      - name: Atribuir autor da PR
-        if: github.event.pull_request.user.type == 'User'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.html_url }}
-          AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: gh pr edit "$PR" --add-assignee "$AUTHOR"
+      - uses: he4rt/.github/actions/auto-assign@3f3ca844aeab9a0c2d63a5f661284425f1123a8b # main


### PR DESCRIPTION
## Summary
- Replaces inline `gh pr edit` script with the shared `he4rt/.github/actions/auto-assign` composite action
- Pins the action reference by commit SHA (`3f3ca84`) to satisfy `zizmor --persona=auditor`
- Fixes pt-BR comment ("à PR" → "ao PR")

## Test plan
- [x] `uvx zizmor . --persona=auditor` returns 0 findings
- [x] New PRs are still auto-assigned to the author