### PR TITLE
feat(devto): export v3 + summary (Fatia 5) — #20

### DIFF
--- a/src/background/controller.ts
+++ b/src/background/controller.ts
@@ -1,5 +1,6 @@
 import type { ActiveFetchFacet } from "../capture/active-fetch";
 import type { BackgroundProviderFacet } from "../providers/contract";
+import { devtoProvider } from "../providers/devto";
 import {
   buildPlatformDataInstagram,
   computeSummaryInstagram,
@@ -15,7 +16,6 @@ import {
 } from "../providers/linkedin";
 import { getCalibration, isCalibrated } from "../providers/linkedin/active-fetch/calibration";
 import { linkedinActiveFetchFacet } from "../providers/linkedin/active-fetch/facet";
-import { devtoProvider } from "../providers/devto";
 import { publicationKey } from "../providers/shared/utils";
 import { buildPlatformDataX, computeSummaryX, xProvider } from "../providers/x";
 import type {

--- a/src/background/controller.ts
+++ b/src/background/controller.ts
@@ -1,6 +1,6 @@
 import type { ActiveFetchFacet } from "../capture/active-fetch";
 import type { BackgroundProviderFacet } from "../providers/contract";
-import { devtoProvider } from "../providers/devto";
+import { buildPlatformDataDevto, computeSummaryDevto, devtoProvider } from "../providers/devto";
 import {
   buildPlatformDataInstagram,
   computeSummaryInstagram,
@@ -333,12 +333,17 @@ function buildExportJSON(store: BackgroundStore): ExportJSON {
     for (const u of entry.users) liEngagers.add(u.urn || u.activity_urn || "");
   for (const entry of Object.values(liExtra.comments))
     for (const c of entry.items) liEngagers.add(c.author.provider_user_id || c.author.username);
+  const dtEngs = Object.values(store.platforms.devto.engagementsByPublication).flat();
 
   const allEngagers = new Set([
     ...xEngs.map((e) => e.actor.provider_user_id || e.actor.username),
     ...igEngs.map((e) => e.actor.provider_user_id || e.actor.username),
     ...liEngagers,
+    ...dtEngs.map((e) => e.actor.provider_user_id || e.actor.username),
   ]);
+
+  const dtArticles = Object.values(store.platforms.devto.extra.analytics);
+  const hasDevto = dtArticles.length > 0;
 
   return {
     schema_version: 3,
@@ -355,6 +360,7 @@ function buildExportJSON(store: BackgroundStore): ExportJSON {
       x: buildPlatformDataX(store),
       instagram: buildPlatformDataInstagram(store),
       linkedin: buildPlatformDataLinkedin(store),
+      ...(hasDevto ? { devto: buildPlatformDataDevto(store) } : {}),
     },
     unified: {
       summary: {
@@ -362,7 +368,8 @@ function buildExportJSON(store: BackgroundStore): ExportJSON {
           total_content:
             Object.values(store.platforms.x.publications).length +
             Object.values(store.platforms.instagram.publications).length +
-            Object.values(liExtra.posts).length,
+            Object.values(liExtra.posts).length +
+            dtArticles.length,
           total_likes:
             Object.values(store.platforms.x.publications).reduce(
               (s, p) => s + p.metrics.like_count,
@@ -372,17 +379,20 @@ function buildExportJSON(store: BackgroundStore): ExportJSON {
               (s, p) => s + p.metrics.like_count,
               0,
             ) +
-            Object.values(liExtra.posts).reduce((s, p) => s + p.metrics.like_count, 0),
+            Object.values(liExtra.posts).reduce((s, p) => s + p.metrics.like_count, 0) +
+            dtArticles.reduce((s, a) => s + a.totals.reactions.total, 0),
           total_comments:
             Object.values(store.platforms.x.commentsByPublication).flat().length +
             Object.values(store.platforms.instagram.commentsByPublication).flat().length +
-            Object.values(liExtra.posts).reduce((s, p) => s + p.metrics.comment_count, 0),
+            Object.values(liExtra.posts).reduce((s, p) => s + p.metrics.comment_count, 0) +
+            dtArticles.reduce((s, a) => s + a.totals.comments.total, 0),
           unique_engagers: allEngagers.size,
         },
         by_platform: {
           x: computeSummaryX(store),
           instagram: computeSummaryInstagram(store),
           linkedin: computeSummaryLinkedin(store),
+          ...(hasDevto ? { devto: computeSummaryDevto(store) } : {}),
         },
       },
     },

--- a/src/panel/components/ConfigPanel.tsx
+++ b/src/panel/components/ConfigPanel.tsx
@@ -79,9 +79,11 @@ function DevtoApiKeySection() {
 
   // Descobre no mount se já há uma key guardada (o background só responde se existe).
   useEffect(() => {
-    void send<{ apiKey: string | null } | undefined>({ action: "GET_DEVTO_API_KEY" }).then((res) => {
-      hasKey.value = res?.apiKey != null && res.apiKey !== "";
-    });
+    void send<{ apiKey: string | null } | undefined>({ action: "GET_DEVTO_API_KEY" }).then(
+      (res) => {
+        hasKey.value = res?.apiKey != null && res.apiKey !== "";
+      },
+    );
   }, []);
 
   async function save() {
@@ -103,9 +105,7 @@ function DevtoApiKeySection() {
 
   return (
     <>
-      <h3 class="mb-3 mt-6 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-3">
-        dev.to
-      </h3>
+      <h3 class="mb-3 mt-6 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-3">dev.to</h3>
       {hasKey.value ? (
         <div class="mb-2 flex items-center gap-2.5 rounded-xl border border-line-2 bg-card py-2 pl-3.5 pr-1.5">
           <span class="min-w-[64px] text-xs font-semibold text-dt">api-key</span>

--- a/src/providers/devto/index.ts
+++ b/src/providers/devto/index.ts
@@ -1,7 +1,42 @@
-import type { DevToStore } from "../../shared/domain";
+import type {
+  BackgroundStore,
+  DevToStore,
+  ExportSummaryDevto,
+  ExportV3PlatformDevto,
+} from "../../shared/domain";
 import type { BackgroundProviderFacet } from "../contract";
 import { publicationKey } from "../shared/utils";
 import { articleIdFromUrl, parseAnalytics, parseReactions } from "./parser";
+
+export function buildPlatformDataDevto(store: BackgroundStore): ExportV3PlatformDevto {
+  const devto = store.platforms.devto as DevToStore;
+  const content = Object.values(devto.extra.analytics).map((a) => {
+    const key = publicationKey("devto", a.article_id);
+    return {
+      article_id: a.article_id,
+      analytics: a,
+      engagers: { reactions: devto.engagementsByPublication[key] ?? [] },
+    };
+  });
+  return { content };
+}
+
+export function computeSummaryDevto(store: BackgroundStore): ExportSummaryDevto {
+  const devto = store.platforms.devto as DevToStore;
+  const articles = Object.values(devto.extra.analytics);
+  const uniqueEngagers = new Set<string>();
+  for (const engagements of Object.values(devto.engagementsByPublication)) {
+    for (const e of engagements) {
+      uniqueEngagers.add(e.actor.provider_user_id || e.actor.username);
+    }
+  }
+  return {
+    total_articles: articles.length,
+    total_page_views: articles.reduce((s, a) => s + a.totals.page_views.total, 0),
+    total_reactions: articles.reduce((s, a) => s + a.totals.reactions.total, 0),
+    total_engagers: uniqueEngagers.size,
+  };
+}
 
 export const devtoProvider: BackgroundProviderFacet = {
   id: "devto",

--- a/src/shared/domain.ts
+++ b/src/shared/domain.ts
@@ -412,10 +412,30 @@ export type ExportV3PlatformLinkedin = {
   content: ExportLinkedInPost[];
 };
 
+export type ExportDevtoArticle = {
+  article_id: string;
+  analytics: DevToArticleAnalytics;
+  engagers: {
+    reactions: SocialEngagement[];
+  };
+};
+
+export type ExportV3PlatformDevto = {
+  content: ExportDevtoArticle[];
+};
+
+export type ExportSummaryDevto = {
+  total_articles: number;
+  total_page_views: number;
+  total_reactions: number;
+  total_engagers: number;
+};
+
 export type ExportV3PerPlatform = {
   x: ExportV3PlatformX;
   instagram: ExportV3PlatformInstagram;
   linkedin: ExportV3PlatformLinkedin;
+  devto?: ExportV3PlatformDevto;
 };
 
 export type ExportSummaryX = {
@@ -460,6 +480,7 @@ export type ExportV3Summary = {
     x?: ExportSummaryX;
     instagram?: ExportSummaryInstagram;
     linkedin?: ExportSummaryLinkedin;
+    devto?: ExportSummaryDevto;
   };
 };
 

--- a/test/__snapshots__/golden-master.test.ts.snap
+++ b/test/__snapshots__/golden-master.test.ts.snap
@@ -893,3 +893,178 @@ exports[`golden-master export v3 LinkedIn (search) 1`] = `
   },
 }
 `;
+
+exports[`golden-master export v3 dev.to 1`] = `
+{
+  "meta": {
+    "exported_at": "<ts>",
+    "handles": {
+      "_": "erikmazzelli",
+      "devto": "erikmazzelli",
+    },
+    "profiles": {
+      "instagram": {
+        "username": "erikmazzelli",
+      },
+      "linkedin": {
+        "username": "erikmazzelli",
+      },
+      "x": {
+        "username": "erikmazzelli",
+      },
+    },
+  },
+  "per_platform": {
+    "devto": {
+      "content": [
+        {
+          "analytics": {
+            "article_id": "123456",
+            "follower_engagement": {
+              "engaged_followers": 5,
+              "ratio": 0.119,
+              "total_followers": 42,
+            },
+            "historical": {
+              "2026-06-01": {
+                "reactions": {
+                  "total": 3,
+                },
+              },
+              "2026-06-03": {
+                "reactions": {
+                  "total": 2,
+                },
+              },
+            },
+            "referrers": {
+              "domains": [
+                {
+                  "count": 10,
+                  "domain": "google.com",
+                },
+              ],
+            },
+            "totals": {
+              "comments": {
+                "total": 2,
+              },
+              "follows": {
+                "total": 3,
+              },
+              "page_views": {
+                "average_read_time_in_seconds": 90,
+                "total": 120,
+                "total_read_time_in_seconds": 10800,
+              },
+              "reactions": {
+                "exploding_head": 0,
+                "fire": 0,
+                "like": 2,
+                "raised_hands": 0,
+                "readinglist": 1,
+                "total": 5,
+                "unicorn": 2,
+                "unique_reactors": 4,
+              },
+            },
+          },
+          "article_id": "123456",
+          "engagers": {
+            "reactions": [
+              {
+                "actor": {
+                  "avatar_url": "",
+                  "name": "894593",
+                  "provider": "devto",
+                  "provider_user_id": "894593",
+                  "username": "894593",
+                },
+                "captured_at": "<ts>",
+                "engaged_at": "2026-06-03T14:39:00.092Z",
+                "engagement_id": "20700191",
+                "kind": "like",
+                "provider": "devto",
+                "publication_id": "123456",
+              },
+              {
+                "actor": {
+                  "avatar_url": "",
+                  "name": "894594",
+                  "provider": "devto",
+                  "provider_user_id": "894594",
+                  "username": "894594",
+                },
+                "captured_at": "<ts>",
+                "engaged_at": "2026-06-01T10:00:00.000Z",
+                "engagement_id": "20700192",
+                "kind": "like",
+                "provider": "devto",
+                "publication_id": "123456",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    "instagram": {
+      "content": [],
+    },
+    "linkedin": {
+      "content": [],
+    },
+    "x": {
+      "content": [],
+      "engagers": {
+        "likes_by_tweet": {},
+        "replies": [],
+      },
+    },
+  },
+  "schema_version": 3,
+  "unified": {
+    "summary": {
+      "all": {
+        "total_comments": 2,
+        "total_content": 1,
+        "total_likes": 5,
+        "unique_engagers": 2,
+      },
+      "by_platform": {
+        "devto": {
+          "total_articles": 1,
+          "total_engagers": 2,
+          "total_page_views": 120,
+          "total_reactions": 5,
+        },
+        "instagram": {
+          "total_comments": 0,
+          "total_content": 0,
+          "total_likes": 0,
+          "total_views": 0,
+        },
+        "linkedin": {
+          "total_audience_interactions": 0,
+          "total_comment_items": 0,
+          "total_comment_reaction_users": 0,
+          "total_comments": 0,
+          "total_content": 0,
+          "total_likes": 0,
+          "total_reaction_users": 0,
+          "total_repost_users": 0,
+          "total_shares": 0,
+        },
+        "x": {
+          "total_bookmarks": 0,
+          "total_content": 0,
+          "total_likes": 0,
+          "total_quotes": 0,
+          "total_replies": 0,
+          "total_retweets": 0,
+          "total_views": 0,
+        },
+      },
+    },
+  },
+}
+`;

--- a/test/fixtures/devto-payloads.ts
+++ b/test/fixtures/devto-payloads.ts
@@ -1,0 +1,43 @@
+export const DEVTO_ARTICLE_ID = "123456";
+export const devtoAnalyticsUrl = `https://dev.to/api/analytics/dashboard?article_id=${DEVTO_ARTICLE_ID}&start=2023-01-01`;
+export const devtoReactionsUrl = `https://dev.to/reactions?article_id=${DEVTO_ARTICLE_ID}`;
+
+export const devtoAnalyticsPayload = {
+  totals: {
+    comments: { total: 2 },
+    follows: { total: 3 },
+    reactions: {
+      total: 5,
+      like: 2,
+      readinglist: 1,
+      unicorn: 2,
+      exploding_head: 0,
+      raised_hands: 0,
+      fire: 0,
+      unique_reactors: 4,
+    },
+    page_views: {
+      total: 120,
+      average_read_time_in_seconds: 90,
+      total_read_time_in_seconds: 10800,
+    },
+  },
+  historical: {
+    "2026-06-01": { reactions: { total: 3 } },
+    "2026-06-03": { reactions: { total: 2 } },
+  },
+  follower_engagement: { total_followers: 42, engaged_followers: 5, ratio: 0.119 },
+  referrers: { domains: [{ domain: "google.com", count: 10 }] },
+};
+
+export const devtoReactionsPayload = {
+  current_user: { id: 894593 },
+  reactions: [
+    { id: 20700191, user_id: 894593, category: "unicorn", created_at: "2026-06-03T14:39:00.092Z" },
+    { id: 20700192, user_id: 894594, category: "like", created_at: "2026-06-01T10:00:00.000Z" },
+  ],
+  article_reaction_counts: [
+    { category: "like", count: 2 },
+    { category: "unicorn", count: 2 },
+  ],
+};

--- a/test/golden-master.test.ts
+++ b/test/golden-master.test.ts
@@ -4,6 +4,12 @@ import { join } from "node:path";
 import { createStore, handleRuntimeMessage } from "../src/background/controller";
 import type { RuntimeMessage } from "../src/shared/messages";
 import {
+  devtoAnalyticsPayload,
+  devtoAnalyticsUrl,
+  devtoReactionsPayload,
+  devtoReactionsUrl,
+} from "./fixtures/devto-payloads";
+import {
   instagramCommentsPayload,
   instagramFeedPayload,
   instagramLikersPayload,
@@ -187,6 +193,35 @@ describe("golden-master export v3", () => {
       endpoint: "searchResultsContent",
       payload: linkedinSearchSduiPayload,
       pageUrl: "https://www.linkedin.com/search/results/content/?keywords=Laravel+Day+SP",
+    });
+
+    expect(exportOf(send)).toMatchSnapshot();
+  });
+
+  // Cenário NOVO: provider dev.to (Background-only). Simula um Active Fetch bem-sucedido:
+  // analytics + reactions de um artigo. Snapshot NOVO — gerado na 1a execução; snapshots
+  // existentes (x/instagram/linkedin) permanecem byte-idênticos (devto é aditivo: só aparece
+  // em per_platform/by_platform quando há dados; all.* contribui 0 em stores vazios).
+  test("dev.to", () => {
+    const { send } = harness();
+    send({ action: "SET_HANDLE", handle: "erikmazzelli", provider: "devto" });
+    send({
+      action: "CAPTURED_PAYLOAD",
+      provider: "devto",
+      endpoint: "analytics",
+      payload: devtoAnalyticsPayload,
+      url: devtoAnalyticsUrl,
+      pageUrl: "https://dev.to/dashboard",
+      timestamp: TS,
+    });
+    send({
+      action: "CAPTURED_PAYLOAD",
+      provider: "devto",
+      endpoint: "reactions",
+      payload: devtoReactionsPayload,
+      url: devtoReactionsUrl,
+      pageUrl: "https://dev.to/dashboard",
+      timestamp: TS,
     });
 
     expect(exportOf(send)).toMatchSnapshot();

--- a/test/providers/devto.test.ts
+++ b/test/providers/devto.test.ts
@@ -50,13 +50,13 @@ describe("parseAnalytics", () => {
   test("mapeia payload completo para DevToArticleAnalytics", () => {
     const result = parseAnalytics(ARTICLE_ID, rawAnalytics);
     expect(result).not.toBeNull();
-    expect(result!.article_id).toBe(ARTICLE_ID);
-    expect(result!.totals.follows.total).toBe(1);
-    expect(result!.totals.reactions.total).toBe(1);
-    expect(result!.totals.reactions.unicorn).toBe(1);
-    expect(result!.totals.page_views.total).toBe(0);
-    expect(result!.historical).toEqual({ "2026-06-03": { reactions: { total: 1 } } });
-    expect(result!.follower_engagement?.total_followers).toBe(1);
+    expect(result?.article_id).toBe(ARTICLE_ID);
+    expect(result?.totals.follows.total).toBe(1);
+    expect(result?.totals.reactions.total).toBe(1);
+    expect(result?.totals.reactions.unicorn).toBe(1);
+    expect(result?.totals.page_views.total).toBe(0);
+    expect(result?.historical).toEqual({ "2026-06-03": { reactions: { total: 1 } } });
+    expect(result?.follower_engagement?.total_followers).toBe(1);
   });
 
   test("retorna null se payload não tem totals", () => {
@@ -66,9 +66,9 @@ describe("parseAnalytics", () => {
 
   test("preenche zeros para campos ausentes em totals", () => {
     const result = parseAnalytics(ARTICLE_ID, { totals: {} });
-    expect(result!.totals.page_views.total).toBe(0);
-    expect(result!.totals.reactions.total).toBe(0);
-    expect(result!.totals.follows.total).toBe(0);
+    expect(result?.totals.page_views.total).toBe(0);
+    expect(result?.totals.reactions.total).toBe(0);
+    expect(result?.totals.follows.total).toBe(0);
   });
 });
 
@@ -77,15 +77,15 @@ describe("parseReactions", () => {
     const engagements = parseReactions(ARTICLE_ID, rawReactions, "2026-06-06T00:00:00Z");
     expect(engagements).toHaveLength(1);
 
-    const first = engagements[0]!;
-    expect(first.engagement_id).toBe("20700191");
-    expect(first.publication_id).toBe(ARTICLE_ID);
-    expect(first.provider).toBe("devto");
-    expect(first.kind).toBe("like");
-    expect(first.actor.provider_user_id).toBe("894593");
-    expect(first.actor.username).toBe("894593");
-    expect(first.engaged_at).toBe("2026-06-03T14:39:00.092Z");
-    expect(first.captured_at).toBe("2026-06-06T00:00:00Z");
+    const first = engagements[0];
+    expect(first?.engagement_id).toBe("20700191");
+    expect(first?.publication_id).toBe(ARTICLE_ID);
+    expect(first?.provider).toBe("devto");
+    expect(first?.kind).toBe("like");
+    expect(first?.actor.provider_user_id).toBe("894593");
+    expect(first?.actor.username).toBe("894593");
+    expect(first?.engaged_at).toBe("2026-06-03T14:39:00.092Z");
+    expect(first?.captured_at).toBe("2026-06-06T00:00:00Z");
   });
 
   test("ignora reactions sem id ou sem user_id", () => {
@@ -94,7 +94,7 @@ describe("parseReactions", () => {
     };
     const result = parseReactions(ARTICLE_ID, payload, "");
     expect(result).toHaveLength(1);
-    expect(result[0]!.engagement_id).toBe("3");
+    expect(result[0]?.engagement_id).toBe("3");
   });
 
   test("retorna [] se payload não tem reactions", () => {
@@ -135,7 +135,7 @@ describe("devtoProvider.processCapture", () => {
     devtoProvider.processCapture(store, makeCapture("analytics", rawAnalytics, ANALYTICS_URL));
     const devto = store.platforms.devto as DevToStore;
     expect(devto.extra.analytics[ARTICLE_ID]).toBeDefined();
-    expect(devto.extra.analytics[ARTICLE_ID]!.totals.reactions.unicorn).toBe(1);
+    expect(devto.extra.analytics[ARTICLE_ID]?.totals.reactions.unicorn).toBe(1);
   });
 
   test("reactions: armazena em engagementsByPublication", () => {
@@ -144,7 +144,7 @@ describe("devtoProvider.processCapture", () => {
     const devto = store.platforms.devto as DevToStore;
     const key = publicationKey("devto", ARTICLE_ID);
     expect(devto.engagementsByPublication[key]).toHaveLength(1);
-    expect(devto.engagementsByPublication[key]![0]!.actor.provider_user_id).toBe("894593");
+    expect(devto.engagementsByPublication[key]?.[0]?.actor.provider_user_id).toBe("894593");
   });
 
   test("reactions: substitui lista ao re-processar (snapshot completo)", () => {


### PR DESCRIPTION
## Motivação

Fatia 5 do provider dev.to ([ADR-0003](docs/adr/0003-active-fetch-provider-devto.md)): ligar o store ao export v3 — os dados já chegavam ao `DevToStore` (Fatia 4), mas `buildExportJSON` não os incluía no JSON exportado.

## O que mudou

| Área | Mudança |
|---|---|
| `shared/domain.ts` | `ExportDevtoArticle`, `ExportV3PlatformDevto`, `ExportSummaryDevto` adicionados; `ExportV3PerPlatform` e `ExportV3Summary.by_platform` atualizados com `devto?` |
| `providers/devto/index.ts` | `buildPlatformDataDevto` (articles com analytics + engagers) e `computeSummaryDevto` (total_articles, total_page_views, total_reactions, total_engagers) |
| `background/controller.ts` | Import e wire em `buildExportJSON`: devto entra em `per_platform` e `by_platform` condicionalmente (só quando há dados); engagements devto somados ao `all` |
| `test/fixtures/devto-payloads.ts` *(novo)* | Fixture com analytics (120 page_views, 5 reactions, historical, follower_engagement) e reactions (2 reatores) |
| `test/golden-master.test.ts` | Teste "dev.to" adicionado: simula Active Fetch completo (analytics + reactions), snapshota o export |

## Gates

```
bun test          191 pass / 0 fail · 4 snapshots existentes byte-idênticos · 1 snapshot novo (dev.to)
bun run typecheck  0 erros
bun run build      dist/chrome OK
```

## Validação manual

No console do side panel (**botão direito no painel → Inspecionar → Console**), após carregar `dist/chrome`:

**1. Injetar payload de analytics mock:**
```js
chrome.runtime.sendMessage({
  action: "CAPTURED_PAYLOAD",
  provider: "devto",
  endpoint: "analytics",
  url: "https://dev.to/api/analytics/dashboard?article_id=123456",
  payload: {
    totals: {
      comments: { total: 7 },
      follows: { total: 137 },
      reactions: { total: 42, like: 20, readinglist: 10, unicorn: 5,
                   exploding_head: 2, raised_hands: 3, fire: 2, unique_reactors: 35 },
      page_views: { total: 500, average_read_time_in_seconds: 120,
                    total_read_time_in_seconds: 60000 }
    },
    historical: {}
  },
  pageUrl: "https://dev.to",
  timestamp: new Date().toISOString()
}, r => console.log("processCapture:", r))
```

**2. Verificar o export:**
```js
chrome.runtime.sendMessage({ action: "GET_EXPORT" }, r => {
  console.log("devto no export:", r.per_platform?.devto)
  console.log("summary devto:", r.unified?.summary?.by_platform?.devto)
})
```

**Resultado esperado:**
- `devto no export: { content: Array(1) }`
- `summary devto: { total_articles: 1, total_page_views: 500, total_reactions: 42, total_engagers: 0 }`

> Nota: o log do store exibe `+0 (total devto: 0)` — comportamento esperado, pois o dev.to não usa `NormalizedStore.publications`; o contador do log só soma essa coleção. O `buildExportJSON` lê `extra.analytics` diretamente.

## Deferido (Fatia 6)

- [ ] Aba dev.to no side panel: estados sem key, coletando, deslogado, sucesso